### PR TITLE
changed port to allow for autoconnect within addon

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -102,7 +102,7 @@ WORKDIR /languagetool
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
-HEALTHCHECK --interval=30s --timeout=10s --start-period=10s CMD wget --quiet --post-data "language=en-US&text=a simple test" -O - http://localhost:8010/v2/check > /dev/null 2>&1  || exit 1
-EXPOSE 8010
+HEALTHCHECK --interval=30s --timeout=10s --start-period=10s CMD wget --quiet --post-data "language=en-US&text=a simple test" -O - http://localhost:8081/v2/check > /dev/null 2>&1  || exit 1
+EXPOSE 8081
 
 ENTRYPOINT ["/sbin/tini", "-g", "-e", "143", "--", "/entrypoint.sh"]

--- a/Dockerfile.fasttext
+++ b/Dockerfile.fasttext
@@ -118,7 +118,7 @@ WORKDIR /languagetool
 COPY --chown=languagetool entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
-HEALTHCHECK --interval=30s --timeout=10s --start-period=10s CMD wget --quiet --post-data "language=en-US&text=a simple test" -O - http://localhost:8010/v2/check > /dev/null 2>&1  || exit 1
-EXPOSE 8010
+HEALTHCHECK --interval=30s --timeout=10s --start-period=10s CMD wget --quiet --post-data "language=en-US&text=a simple test" -O - http://localhost:8081/v2/check > /dev/null 2>&1  || exit 1
+EXPOSE 8081
 
 ENTRYPOINT ["/sbin/tini", "-g", "-e 143", "--", "/entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - no-new-privileges
     ports:
       # Using default port from the image
-      - 8010:8010
+      - 8081:8081
     environment:
       # OVERRIDE: comma seperated list of ngram language models to download (if not existing)
       #           Valid languages are "en", "de", "es", "fr" and "nl". Image default: none

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -296,7 +296,7 @@ read -ra FINAL_EXECUTE_ARGS <<< "${EXECUTE_ARGS}"
 
 exec "${FINAL_EXECUTE_ARGS[@]}" \
     java "${FINAL_JAVA_OPTS[@]}" -Dlogback.configurationFile="/tmp/logback.xml" -cp languagetool-server.jar org.languagetool.server.HTTPServer \
-      --port "${LISTEPORT:-8010}" \
+      --port "${LISTEPORT:-8081}" \
       --public \
       --allow-origin "*" \
       --config /tmp/config.properties


### PR DESCRIPTION
bug: within the firefox addon the localserver option wasn't connecting properly.
fix: changing the port to the [documented](https://dev.languagetool.org/http-server) port fixed this autoconnect issue

effective change:
changed port `8010` to `8081`

tested on:
browser addon for firefox Version 8.14.3

![image](https://github.com/user-attachments/assets/7885655c-33f3-421d-bd85-66361a777dda)
