### PR TITLE
Breaking: upgrade to LT6.6, upgrade to Java 21.0.7+6, use default LT …

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,4 @@
+.idea
 fasttext
 ngrams
+compose.yml

--- a/Dockerfile.fasttext
+++ b/Dockerfile.fasttext
@@ -1,6 +1,6 @@
-ARG LT_VERSION=6.5
-ARG JAVA_VERSION=jdk-21.0.6+7
-FROM alpine:3.18.9 as base
+ARG LT_VERSION=6.6
+ARG JAVA_VERSION=jdk-21.0.7+6
+FROM alpine:3.18.12 as base
 
 FROM base AS java_base
 
@@ -9,7 +9,7 @@ ENV LANG=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8
 
 RUN set -eux; \
-    apk add --no-cache libretls musl-locales musl-locales-lang tzdata zlib unzip; \
+    apk add --upgrade --no-cache libretls musl-locales musl-locales-lang tzdata zlib unzip; \
     rm -rf /var/cache/apk/*
 
 FROM java_base AS prepare
@@ -48,10 +48,10 @@ RUN set -eux; \
 RUN set -eux; \
     wget -O /tmp/LanguageTool-${LT_VERSION}.zip https://www.languagetool.org/download/LanguageTool-${LT_VERSION}.zip; \
     unzip "/tmp/LanguageTool-${LT_VERSION}.zip"; \
-    mv /LanguageTool-* "/languagetool"; \
+    mv /LanguageTool-*/ "/languagetool"; \
 	cd "/languagetool"; \
     ${JAVA_HOME}/bin/jar xf languagetool-server.jar logback.xml; \
-    rm "/tmp/LanguageTool-${LT_VERSION}.zip" 
+    rm "/tmp/LanguageTool-${LT_VERSION}.zip"
 
 RUN set -eux; \
     LT_DEPS=$("${JAVA_HOME}/bin/jdeps" \
@@ -67,9 +67,7 @@ RUN set -eux; \
         --strip-debug \
         --no-man-pages \
         --no-header-files \
-        --compress=2 \
         --output /opt/java/customjre
-
 
 FROM base AS fasttext
 
@@ -84,16 +82,16 @@ RUN set -eux; \
     make -C fastText;\
     upx -5 -o /fastText/fasttext-upx /fastText/fasttext
 
-
 FROM java_base
 
 RUN set -eux; \
-    apk add --no-cache bash shadow libstdc++ gcompat su-exec tini xmlstarlet; \
+    apk add --no-cache bash shadow libstdc++ gcompat su-exec tini xmlstarlet nss_wrapper; \
     rm -f /var/cache/apk/*
 
 RUN set -eux; \
     groupmod --gid 783 --new-name languagetool users; \
-    adduser -u 783 -S languagetool -G languagetool -H
+    adduser -u 783 -S languagetool -G languagetool -H; \
+    mkdir -p /ngrams /fasttext
 
 COPY --from=prepare /languagetool/ /languagetool
 COPY --from=prepare /opt/java/customjre/ /opt/java/customjre
@@ -108,17 +106,25 @@ ENV JAVA_HOME=/opt/java/customjre \
     MAP_GID=783 \
     LOG_LEVEL=INFO \
     LOGBACK_CONFIG=./logback.xml \
-    DISABLE_CHMOD=false \
-    DISABLE_FASTTEXT=false
+    DISABLE_FILE_OWNER_FIX=false \
+    DISABLE_FASTTEXT=false \
+    LISTEN_PORT=8081
 
 ENV PATH=${JAVA_HOME}/bin:${PATH}
 
 WORKDIR /languagetool
 
-COPY --chown=languagetool entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
+HEALTHCHECK --interval=30s --timeout=10s --start-period=10s CMD wget --quiet --post-data "language=en-US&text=a simple test" -O - http://localhost:${LISTEN_PORT}/v2/check > /dev/null 2>&1  || exit 1
+EXPOSE ${LISTEN_PORT}
 
-HEALTHCHECK --interval=30s --timeout=10s --start-period=10s CMD wget --quiet --post-data "language=en-US&text=a simple test" -O - http://localhost:8010/v2/check > /dev/null 2>&1  || exit 1
-EXPOSE 8010
+COPY --chmod=755 entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/sbin/tini", "-g", "-e", "143", "--", "/entrypoint.sh"]
 
-ENTRYPOINT ["/sbin/tini", "-g", "-e 143", "--", "/entrypoint.sh"]
+LABEL org.opencontainers.image.title="meyay/languagetool"
+LABEL org.opencontainers.image.description="Minimal Docker Image for LanguageTool with fasttext support and automatic ngrams download"
+LABEL org.opencontainers.image.version="6.6-0"
+LABEL org.opencontainers.image.created="2025-04-19"
+LABEL org.opencontainers.image.licenses="LGPL-2.1"
+LABEL org.opencontainers.image.documentation="https://github.com/meyayl/docker-languagetool"
+LABEL org.opencontainers.image.source="https://github.com/meyayl/docker-languagetool"
+LABEL org.opencontainers.image.url="https://github.com/languagetool-org/languagetool"

--- a/README.md
+++ b/README.md
@@ -1,43 +1,62 @@
-# LanguageTool
+# LanguageTool Docker Image
 
 > [LanguageTool](https://www.languagetool.org/) is an Open Source proofreading software for English, French, German, Polish, Russian, and [more than 20 other languages](https://languagetool.org/languages/). It finds many errors that a simple spell checker cannot detect.
 
-The source repository can be found [here](https://github.com/meyayl/docker-languagetool).
+The source repository can be found [here](https://github.com/meyayl/docker-languagetool). <br/>
+The Docker Hub repository can be found [here](https://hub.docker.com/r/meyay/languagetool).
 
-About this image:
+## Features
 
-- Uses official [release zip](https://languagetool.org/download/)
-- Uses the latest Alpine 3.21 base image
-- Uses custom Eclipse Temurin 21 JRE limited to modules required by the current LanguageTool release
+- Uses official LanguageTool [release zip](https://languagetool.org/download/)
+- Built on latest Alpine 3.21 base image
+- Custom Eclipse Temurin 21 JRE (optimized with required modules only)
+- Uses `tini` to handle container signals properly
 - includes `fasttext`
 - includes `su-exec`
-  - container starts as root and executes languagetool as restricted user using `exec su-exec`
-  - container fixes folder ownership for ngrams and fasttext folders
-- Entrypoint uses `tini` to suppress the container exiting with status code 143 (LanguageTool does not handle SIGTERM as it should)
+- container starts as privileged user (=root) and executes LanguageTool as unprivileged user using `exec su-exec` (default)
+  - optional: container fixes folder ownership for ngrams and fasttext folders (default)
+  - optional: support user mapping (make sure to check MAP_UID and MAP_GID below)
+  - optional: works with read-only filesystem (uses nss_wrapper for user mapping)
+- container can be started as unprivileged user instead of root user
+  - optional: works with read-only filesystem
 - optional: downloads ngram language modules if configured (if they don't already exist)
 - optional: downloads fasttext module (if it doesn't already exist)
-- optional: support user mapping (make sure to check MAP_UID and MAP_GID below) is started as root user (default).
-- optional: can be started as unprivileged user instead of root user
-- optional: set log level
-- optional: works with read-only filesystem
+- optional: allows to set log level
+
+>⚠️ BREAKING CHANGE in version 6.6-0 ⚠️
+>
+>The default listen port inside the container has changed:
+>- Previous versions: port 8010
+>- New version (6.6-0): port 8081
+>
+>Either update your port mapping configuration to use the new port, or set the environment
+>variable `LISTEN_PORT` to `8010` to retain old behavior.
 
 ## Setup
 
-### Docker CLI Usage
+The following subsections show usage examples.<br/>
+An example compose file can be downloaded from [here](https://raw.githubusercontent.com/meyayl/docker-languagetool/main/docker-compose.yml).
 
-#### Start container as root user with read-only filesystem, start LanguageTool as MAP_UID:MAP_GID
+### Start container as root user with read-only filesystem, start LanguageTool as MAP_UID:MAP_GID
+
+Start the container as root user with all required capabilities to fix file ownership, and execute LanguageTool as unprivileged user.
+
+#### Docker CLI Usage
 
 ```sh
 docker run -d \
   --name languagetool \
   --restart unless-stopped \
   --cap-drop ALL \
+  --cap-add CAP_CHOWN \
+  --cap-add CAP_DAC_OVERRIDE \
   --cap-add CAP_SETUID \
   --cap-add CAP_SETGID \
-  --cap-add CAP_CHOWN \
   --security-opt no-new-privileges \
-  --publish 8010:8010 \
+  --publish 8081:8081 \
   --env download_ngrams_for_langs=en \
+  --env MAP_UID=783 \
+  --env MAG_GID=783 \
   --read-only \
   --tmpfs /tmp \
   --volume $PWD/ngrams:/ngrams \
@@ -45,7 +64,48 @@ docker run -d \
   meyay/languagetool:latest
 ```
 
-#### Start container as unpriveleged user with read-only filesystem
+#### Docker Compose Usage
+
+```yaml
+---
+services:
+  languagetool:
+    image: meyay/languagetool:latest
+    container_name: languagetool
+    restart: unless-stopped
+    read_only: true
+    tmpfs:
+      - /tmp
+    cap_drop:
+      - ALL
+    cap_add:
+      - CAP_CHOWN
+      - CAP_DAC_OVERRIDE
+      - CAP_SETUID
+      - CAP_SETGID
+    security_opt:
+      - no-new-privileges
+    ports:
+      - 8081:8081
+    environment:
+      download_ngrams_for_langs: en
+      MAP_UID: 783
+      MAP_GID: 783
+    volumes:
+      - ./ngrams:/ngrams
+      - ./fasttext:/fasttext
+```
+
+### Start container as unprivileged user with read-only filesystem
+
+Start the container as unprivileged user specified by the `--user` argument.
+The container will neither try to fix file ownership, nor does it require any additional capabilities.
+
+You need to make sure the directories bound as volume do exist, and are owned by the same user and/or group specified in the `--user`argument!
+
+This is the recommended way to run the container.
+
+#### Docker CLI Usage
 
 ```sh
 docker run -d \
@@ -53,7 +113,7 @@ docker run -d \
   --restart unless-stopped \
   --cap-drop ALL \
   --security-opt no-new-privileges \
-  --publish 8010:8010 \
+  --publish 8081:8081 \
   --env download_ngrams_for_langs=en \
   --user 783:783 \
   --read-only \
@@ -63,42 +123,7 @@ docker run -d \
   meyay/languagetool:latest
 ```
 
-Note: the container will not fix ownership and permissions, so make sure the directories bound as volume exist and are owned by the user!
-
-### Docker Compose Usage
-
-#### Start container as root user with read-only filesystem, start LanguageTool as MAP_UID:MAP_GID
-
-```yaml
----
-services:
-  languagetool:
-    image: meyay/languagetool:latest
-    container_name: languagetool
-    restart: always
-    read_only: true
-    tmpfs:
-      - /tmp
-    cap_drop:
-      - ALL
-    cap_add:
-      - CAP_SETUID
-      - CAP_SETGID
-      - CAP_CHOWN
-    security_opt:
-      - no-new-privileges
-    ports:
-      - 8010:8010
-    environment:
-      download_ngrams_for_langs: en
-    volumes:
-      - ./ngrams:/ngrams
-      - ./fasttext:/fasttext
-```
-
-An example compose file can be downloaded from [here](https://raw.githubusercontent.com/meyayl/docker-languagetool/main/docker-compose.yml).
-
-#### Start container as unpriveleged user with read-only filesystem
+#### Docker Compose Usage
 
 ```yaml
 ---
@@ -116,7 +141,7 @@ services:
     security_opt:
       - no-new-privileges
     ports:
-      - 8010:8010
+      - 8081:8081
     environment:
       download_ngrams_for_langs: en
     volumes:
@@ -126,46 +151,56 @@ services:
 
 ## Usage
 
-You need to install and use one of the add-ons from https://languagetool.org/services and configure it to use the self-hosted LanguageTool server `http://{ip-of-your-docker-host}:{published host port}/v2`. The self-hosted LanguageTool server does not come with its own UI!
+You need to install and use one of the add-ons from https://languagetool.org/services and configure it to use the self-hosted LanguageTool server `http://{ip-of-your-docker-host}:{published host port}/v2`. The self-hosted LanguageTool server does not come with its own UI or supports user authentication!
 
-Note: some add-ons require https connections, which is not (and will not be) supported by this image. You will need to put a reverse proxy in front of it to take care of the TLS termination.
+NOTE: Some add-ons require https connections, which is not (and will not be) supported by this image. You will need to put a reverse proxy in front of it to take care of the TLS termination.
 
 ## Capabilities
 
-If the container is started as unpriviliged user, the capabilites `CAP_SETUID`, `CAP_SETGID`, and `CAP_CHOWN` are not required, and can be omitted.
-If the container is started as privliged user (default), and the environment variable `DISABLE_PERMISSION_FIX` is set to `true`, the capability `CAP_CHOWN` is not required and can be omitted
+If the container is started as unprivileged user, the capabilities `CAP_CHOWN` `CAP_DAC_OVERRIDE`, `CAP_SETUID` and `CAP_SETGID`,  are not required, and can be omitted.
+If the container is started as privileged user (default), and the environment variable `DISABLE_FILE_OWNER_FIX` is set to `true`, the capabilities `CAP_CHOWN` and `CAP_DAC_OVERRIDE` are not required and can be omitted.
+
+## Ports
+
+The self-hosted LanguageTool server in the container is listening on port `8081` by default.
+
+It can be changed using the environment variable `LISTEN_PORT`.
 
 ## Volumes
 
-| Container Path         | DESCRIPTION                                                                                                                                                        |
-|------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| /ngrams                | Location to store the ngram language models. If container is started as unprivileged user, make sure the host path is owned by the user that starts the container. |
-| /fasttext              | Location to store the fasttext model. If container is started as unprivileged user, make sure the host path is owned by the user that starts the container.        |
-| /tmp                   | Location to store the created logback.xml and config.property. Preferably a tmpfs mount.                                                                           |
+| Required | Container Path | DESCRIPTION                                                                                                                                                                     |
+|----------|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| no       | /ngrams        | Location to store the ngram language models. If container is started as unprivileged user, make sure the host path is owned by the user and/or group that starts the container. |
+| no       | /fasttext      | Location to store the fasttext model. If container is started as unprivileged user, make sure the host path is owned by the user and/or group that starts the container.        |
+| yes      | /tmp           | Location to store the created logback.xml and config.property. Preferably a tmpfs mount. |
 
-
+Restrictions if only required volumes are used:
+- privileged container: ngram language models and fasttext model will written into the container filesystem.
+- read-only filesystem: neither ngram language models, nor fasttext model can be used.
+- unprivileged container: neither ngram language models, nor fasttext model can be used.
 
 ## Parameters
 
-The environment parameters are split into two halves, separated by an equal, the left-hand side represents the variable names (use them as is) the right-hand side the value (change if necessary).
+The environment parameters are split into two halves, separated by an equal or colon, the left-hand side represents the variable name (use it as is), the right-hand side the value (change if necessary).
 
-| ENV| DEFAULT                 | DESCRIPTION                                                                                                                                                                                                                     |
-| ------ |-------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ENV                       | DEFAULT                 | DESCRIPTION                                                                                                                                                                                                                     |
+|---------------------------|-------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | download_ngrams_for_langs | none                    | Optional: Comma separated list of languages to download ngrams for. Skips download if the ngrams for that language already exist. Valid languages: `en`, `de`, `es`, `fr` and `nl`. Example value: `en,de`                      |
-| langtool_languageModel | /ngrams                 | Optional: The base path to the ngrams models.                                                                                                                                                                                   |
-| langtool_fasttextBinary | /usr/local/bin/fasttext | Optional: Path to the fasttext binary. Change only if you want to test your own compiled binary. Don't forget to map it into the container as volume.                                                                           |
-| langtool_fasttextModel | /fasttext/lid.176.bin   | Optional: The container path to the fasttext model binary. If the variable is set, the fasttext model will be downloaded if doesn't exist yet.                                                                                  |
-| langtool_*|                         | Optional: An arbitrary languagetool configuration, consisting of the prefix `langtool_` and the key name as written in the config file. Execute `docker run -ti --rm meyay/languagetool help` to see the list of config options |
-| JAVA_XMS | 256m                    | Optional: Minimum size of the Java heap space. Valid suffixes are `m` for megabytes and `g` for gigabytes.                                                                                                                      |
-| JAVA_XMX | 1536m                   | Optional: Maximum size of the Java heap space. Valid suffixes are `m` for megabytes and `g` for gigabytes. Set a higher value if you experience OOM kills, but do not use more than 1/4 of the host memory!                     |
-| JAVA_GC | ShenandoahGC                | Optional: Configure the garbage collector the JVM will use. Valid options are: `SerialGC`, `ParallelGC`, `ParNewGC`, `G1GC`, `ZGC`, `ShenandoahGC`                                                                                            |
-| JAVA_OPTS |                         | Optional: Set you own custom Java options for the JVM. This will render the other JAVA_* options useless.                                                                                                                       |
-| MAP_UID | 783                     | Optional: UID of the user inside the container that runs LanguageTool. If you encounter permission problems with your volumes, make sure to set the parameter to the UID of the host folder owner.                              |
-| MAP_GID | 783                     | Optional: GID of the user inside the container that runs LanguageTool. If you encounter permission problems with your volumes, make sure to set the parameter to the GID of the host folder owner.                              |
-| LOG_LEVEL| INFO                    | Optional: set log level for LanguageTool. Valid options are: `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`.                                                                                                                         |
-| DISABLE_PERMISSION_FIX| false                   | Optional: Disables the permission fix, if set to `true`. Will be used implicitly, if the container is started with an upriviliged user. The Valid options are: `true`, anything else is treated as `false`.                     |
-| DISABLE_FASTTEXT| false                   | Optional: Disables fasttext, if set to `true`, neither the model is downloaded, nor fasttext enabled in LanguageTool.  The Valid options are: `true`, anything else is treated as `false`.                                      |
-| DEBUG_ENTRYPOINT|                         | Optional: Enables debug logs, if set to `true`. The Valid options are: `true`, anything else is treated as `false`.                                                                                                             |
+| langtool_languageModel    | /ngrams                 | Optional: The base path to the ngrams models.                                                                                                                                                                                   |
+| langtool_fasttextBinary   | /usr/local/bin/fasttext | Optional: Path to the fasttext binary. Change only if you want to test your own compiled binary. Don't forget to map it into the container as volume.                                                                           |
+| langtool_fasttextModel    | /fasttext/lid.176.bin   | Optional: The container path to the fasttext model binary. If the variable is set, the fasttext model will be downloaded if doesn't exist yet.                                                                                  |
+| langtool_*                |                         | Optional: An arbitrary LanguageTool configuration, consisting of the prefix `langtool_` and the key name as written in the config file. Execute `docker run -ti --rm meyay/languagetool help` to see the list of config options. |
+| JAVA_XMS                  | 256m                    | Optional: Minimum size of the Java heap space. Valid suffixes are `m` for megabytes and `g` for gigabytes.                                                                                                                      |
+| JAVA_XMX                  | 1536m                   | Optional: Maximum size of the Java heap space. Valid suffixes are `m` for megabytes and `g` for gigabytes. Set a higher value if you experience OOM kills.                                                                      |
+| JAVA_GC                   | ShenandoahGC            | Optional: Configure the garbage collector the JVM will use. Valid options are: `SerialGC`, `ParallelGC`, `ParNewGC`, `G1GC`, `ZGC`, `ShenandoahGC`                                                                              |
+| JAVA_OPTS                 |                         | Optional: Set you own custom Java options for the JVM. This will render the other JAVA_* options useless.                                                                                                                       |
+| LISTEN_PORT               | 8081                    | Optional: Set listen port of the self-hosted LanguageTool server inside the container.                                                                                                                                          |                                                                                                                                                                                                                       
+| MAP_UID                   | 783                     | Optional: UID of the user inside the container that runs LanguageTool. If you encounter permission problems with your volumes, make sure to set the parameter to the UID of the host folder owner.                              |
+| MAP_GID                   | 783                     | Optional: GID of the user inside the container that runs LanguageTool. If you encounter permission problems with your volumes, make sure to set the parameter to the GID of the host folder owner.                              |
+| LOG_LEVEL                 | INFO                    | Optional: Set log level for LanguageTool. Valid options are: `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`.                                                                                                                         |
+| DISABLE_FILE_OWNER_FIX    | false                   | Optional: Disables file ownership fix, if set to `true`. Will be used implicitly, if the container is started with an upriviliged user. The Valid options are: `true`, anything else is treated as `false`.      |
+| DISABLE_FASTTEXT          | false                   | Optional: Disables fasttext, if set to `true`, neither the model is downloaded, nor fasttext enabled in LanguageTool.  The Valid options are: `true`, anything else is treated as `false`.                                      |
+| DEBUG_ENTRYPOINT          |                         | Optional: Enables debug logs, if set to `true`. The Valid options are: `true`, anything else is treated as `false`.                                                                                                             |
 
 ## Fasttext support
 
@@ -187,42 +222,43 @@ Once the image is build, you can `docker compose up -d` like you would do with t
 
 ## Changelog
 
-| Date                          | Tag        | Change                                                                                                                                                                                                                                                                                       |
-|-------------------------------|------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 2025-02-16                    | 6.5-2      | - Update base image to Alpine 3.21.3<br/> - Update Java to 21.0.6+7                                                                                                                                                                                                                         |
-| 2024-10-30                    | 6.5-1      | - Massive refactoring of Entrypoint script<br/> - Update Java to 21.0.5+11                                                                                                                                                                                                                   |
-| 2024-09-29                    | 6.5-0      | - Update to LaguageTool 6.5                                                                                                                                                                                                                                                                  |
-| 2024-09-14                    | 6.4-4      | - Update base image to Alpine 3.20.3                                                                                                                                                                                                                                                         | 
-| 2024-07-31                    | 6.4-3      | - Update base image to Alpine 3.20.2<br/> - Update Java to 21.0.4+7                                                                                                                                                                                                                          |
-| 2024-07-05                    | 6.4-2      | - Update base image to Alpine 3.20.1<br/> - Update Java to 21.0.3+9                                                                                                                                                                                                                          |
-| 2024-05-27                    | 6.4-1      | - Update base image to Alpine 3.20.0                                                                                                                                                                                                                                                         |
-| 2024-04-02                    | 6.4-0      | - Update to LanguageTool 6.4<br/> - Modified entrypoint script, to require 7x5 permissions instead of 7x7 for ngrams and fasttext volumes anymore.                                                                                                                                           | 
-| 2024-03-26                    | 6.3a-5     | - Update Java to 21.0.2+13<br/> - Add capability CAP_CHOWN to README.md and compose file.                                                                                                                                                                                                    | 
-| 2024-02-26                    | 6.3a-4     | - Fix entrypoint script bug that affected new users when downloading the ngram models.                                                                                                                                                                                                       |
-| 2024-02-17                    | 6.3a-3     | - Update base image to Alpine 3.19.1<br/> - Migrate from compiling fasttext to using the Alpine fasttext package.                                                                                                                                                                            |
-| 2024-02-17                    | 6.3a-2     | - Modify Dockerfile to create the languagetool user without home directory<br/> - Modify entrypoint script to modify uid:gid of languagetool user and group if actually changed.                                                                                                             |
-| 2024-02-12                    | 6.3a-1     | - Update base image to Alpine 3.18.6<br/> - Update Java to 17.0.10+7                                                                                                                                                                                                                         |
-| 2023-12-20                    | 6.3a-0     | - Update to LanguageTool 6.3a                                                                                                                                                                                                                                                                |
-| 2023-12-03                    | 6.3-1      | - Update base image to Alpine 3.18.5<br/> - Update Java to 17.0.9+9                                                                                                                                                                                                                          |
-| 2023-10-10                    | 6.3-0      | - Update to LanguageTool 6.3<br/> - Update base image to Alpine 3.18.4<br/> - Update Java to 17.0.8.1+1                                                                                                                                                                                      |
-| 2023-08-10                    | 6.2-1      | - Update base image to Alpine 3.18.3<br/> - Update Java to 17.0.8+7                                                                                                                                                                                                                          |
-| 2023-07-09                    | 6.2-0      | - Update to languagetool 6.2                                                                                                                                                                                                                                                                 |
-| 2023-06-30                    | 6.1-4      | - Update base image to Alpine 3.18.2                                                                                                                                                                                                                                                         |
-| 2023-05-19                    | 6.1-3      | - Update base image to Alpine 3.18.0<br/> - Update Java to 17.0.7+7                                                                                                                                                                                                                          |
-| 2023-04-01                    | 6.1-2      | - Update base image to Alpine 3.17.3.                                                                                                                                                                                                                                                        |
-| 2023-03-28                    | 6.1-1      | - Add logic to set log level                                                                                                                                                                                                                                                                 |
-| 2023-03-28                    | 6.1-0      | - Upgrade to languagetool 6.1                                                                                                                                                                                                                                                                |  
-| 2023-02-23                    | 6.0-5      | - Update base image to Alpine 3.17.2.                                                                                                                                                                                                                                                        |
-| 2023-01-23                    | 6.0-4      | - Update Java to Eclipse Temurin 17.0.6+10.                                                                                                                                                                                                                                                  |
-| 2023-01-15                    | 6.0-3      | - Update base image to Alpine 3.17.1.                                                                                                                                                                                                                                                        |
-| 2023-01-01                    | 6.0-2      | - Add alpine package `gcompat` to satisfy `ld-linux-x86-64.so.2` dependency.<br/>(this fixes the issue of the 6.0-1 image)                                                                                                                                                                   |
-| ~~2022-12-29~~<br/>2023-01-01 | ~~6.0-1~~  | ~~- Upgrade to languagetool 6.0~~<br/> - Removed tag due to ClassPath exception.                                                                                                                                                                                                             |
-| 2022-12-07                    | 5.9-7      | - Fix health check command                                                                                                                                                                                                                                                                   |
-| 2022-12-04                    | 5.9-6      | - Add `help` command to display languagetool configuration items to be used with `languagetool_*`                                                                                                                                                                                            |
-| 2022-12-04                    | 5.9-5      | - Switch to stripped down Eclipse Temurin 17 JRE <br/> - Remove JVM argument `-XX:+UseStringDeduplication` except for G1GC <br/> - Add `tini` to suppress exit code 143 <br/> - Removed `curl` and switch to `wget` <br/> - Print version info about Alpine and Eclipse Temurin during start |
-| 2022-11-29                    | 5.9-4      | - Update base image to Alpine 3.17.0                                                                                                                                                                                                                                                         |
-| 2022-11-24                    | 5.9-3      | - Add support to configure garbage collector <br/> - Add JVM argument `-XX:+UseStringDeduplication` <br/> - Add support to pass custom JAVA_OPTS <br/> - Change Java_Xm? variables to JAVA_XM?                                                                                               |
-| 2022-11-12                    | 5.9-2      | - Update base image to Alpine 3.16.3                                                                                                                                                                                                                                                         |
-| 2022-09-28                    | 5.9-1      | - Update LanguageTool to 5.9                                                                                                                                                                                                                                                                 |
-| 2022-09-10                    | 5.8-2      | - Add user mapping support                                                                                                                                                                                                                                                                   |
-| 2022-09-10                    | 5.8-1      | - Initial release with Alpine 3.16.2, LanguageTool 5.8                                                                                                                                                                                                                                       |
+| Date                          | Tag       | Change                                                                                                                                                                                                                                                                                       |
+|-------------------------------|-----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 2025-04-19                    | 6.6-0     | - Breaking: Changed LISTEN_PORT from 8010 to 8081<br/>Extended sanity checks and log output in entrypoint script<br/> - Update Java to 21.0.7+6                                                                                                                                              |
+| 2025-02-16                    | 6.5-2     | - Update base image to Alpine 3.21.3<br/> - Update Java to 21.0.6+7                                                                                                                                                                                                                          |
+| 2024-10-30                    | 6.5-1     | - Massive refactoring of Entrypoint script<br/> - Update Java to 21.0.5+11                                                                                                                                                                                                                   |
+| 2024-09-29                    | 6.5-0     | - Update to LaguageTool 6.5                                                                                                                                                                                                                                                                  |
+| 2024-09-14                    | 6.4-4     | - Update base image to Alpine 3.20.3                                                                                                                                                                                                                                                         | 
+| 2024-07-31                    | 6.4-3     | - Update base image to Alpine 3.20.2<br/> - Update Java to 21.0.4+7                                                                                                                                                                                                                          |
+| 2024-07-05                    | 6.4-2     | - Update base image to Alpine 3.20.1<br/> - Update Java to 21.0.3+9                                                                                                                                                                                                                          |
+| 2024-05-27                    | 6.4-1     | - Update base image to Alpine 3.20.0                                                                                                                                                                                                                                                         |
+| 2024-04-02                    | 6.4-0     | - Update to LanguageTool 6.4<br/> - Modified entrypoint script, to require 7x5 permissions instead of 7x7 for ngrams and fasttext volumes anymore.                                                                                                                                           | 
+| 2024-03-26                    | 6.3a-5    | - Update Java to 21.0.2+13<br/> - Add capability CAP_CHOWN to README.md and compose file.                                                                                                                                                                                                    | 
+| 2024-02-26                    | 6.3a-4    | - Fix entrypoint script bug that affected new users when downloading the ngram models.                                                                                                                                                                                                       |
+| 2024-02-17                    | 6.3a-3    | - Update base image to Alpine 3.19.1<br/> - Migrate from compiling fasttext to using the Alpine fasttext package.                                                                                                                                                                            |
+| 2024-02-17                    | 6.3a-2    | - Modify Dockerfile to create the LanguageTool user without home directory<br/> - Modify entrypoint script to modify uid:gid of languagetool user and group if actually changed.                                                                                                             |
+| 2024-02-12                    | 6.3a-1    | - Update base image to Alpine 3.18.6<br/> - Update Java to 17.0.10+7                                                                                                                                                                                                                         |
+| 2023-12-20                    | 6.3a-0    | - Update to LanguageTool 6.3a                                                                                                                                                                                                                                                                |
+| 2023-12-03                    | 6.3-1     | - Update base image to Alpine 3.18.5<br/> - Update Java to 17.0.9+9                                                                                                                                                                                                                          |
+| 2023-10-10                    | 6.3-0     | - Update to LanguageTool 6.3<br/> - Update base image to Alpine 3.18.4<br/> - Update Java to 17.0.8.1+1                                                                                                                                                                                      |
+| 2023-08-10                    | 6.2-1     | - Update base image to Alpine 3.18.3<br/> - Update Java to 17.0.8+7                                                                                                                                                                                                                          |
+| 2023-07-09                    | 6.2-0     | - Update to LanguageTool 6.2                                                                                                                                                                                                                                                                 |
+| 2023-06-30                    | 6.1-4     | - Update base image to Alpine 3.18.2                                                                                                                                                                                                                                                         |
+| 2023-05-19                    | 6.1-3     | - Update base image to Alpine 3.18.0<br/> - Update Java to 17.0.7+7                                                                                                                                                                                                                          |
+| 2023-04-01                    | 6.1-2     | - Update base image to Alpine 3.17.3.                                                                                                                                                                                                                                                        |
+| 2023-03-28                    | 6.1-1     | - Add logic to set log level                                                                                                                                                                                                                                                                 |
+| 2023-03-28                    | 6.1-0     | - Upgrade to LanguageTool 6.1                                                                                                                                                                                                                                                                |  
+| 2023-02-23                    | 6.0-5     | - Update base image to Alpine 3.17.2.                                                                                                                                                                                                                                                        |
+| 2023-01-23                    | 6.0-4     | - Update Java to Eclipse Temurin 17.0.6+10.                                                                                                                                                                                                                                                  |
+| 2023-01-15                    | 6.0-3     | - Update base image to Alpine 3.17.1.                                                                                                                                                                                                                                                        |
+| 2023-01-01                    | 6.0-2     | - Add alpine package `gcompat` to satisfy `ld-linux-x86-64.so.2` dependency.<br/>(this fixes the issue of the 6.0-1 image)                                                                                                                                                                   |
+| ~~2022-12-29~~<br/>2023-01-01 | ~~6.0-1~~ | ~~- Upgrade to languagetool 6.0~~<br/> - Removed tag due to ClassPath exception.                                                                                                                                                                                                             |
+| 2022-12-07                    | 5.9-7     | - Fix health check command                                                                                                                                                                                                                                                                   |
+| 2022-12-04                    | 5.9-6     | - Add `help` command to display LanguageTool configuration items to be used with `languagetool_*`                                                                                                                                                                                            |
+| 2022-12-04                    | 5.9-5     | - Switch to stripped down Eclipse Temurin 17 JRE <br/> - Remove JVM argument `-XX:+UseStringDeduplication` except for G1GC <br/> - Add `tini` to suppress exit code 143 <br/> - Removed `curl` and switch to `wget` <br/> - Print version info about Alpine and Eclipse Temurin during start |
+| 2022-11-29                    | 5.9-4     | - Update base image to Alpine 3.17.0                                                                                                                                                                                                                                                         |
+| 2022-11-24                    | 5.9-3     | - Add support to configure garbage collector <br/> - Add JVM argument `-XX:+UseStringDeduplication` <br/> - Add support to pass custom JAVA_OPTS <br/> - Change Java_Xm? variables to JAVA_XM?                                                                                               |
+| 2022-11-12                    | 5.9-2     | - Update base image to Alpine 3.16.3                                                                                                                                                                                                                                                         |
+| 2022-09-28                    | 5.9-1     | - Update LanguageTool to 5.9                                                                                                                                                                                                                                                                 |
+| 2022-09-10                    | 5.8-2     | - Add user mapping support                                                                                                                                                                                                                                                                   |
+| 2022-09-10                    | 5.8-1     | - Initial release with Alpine 3.16.2, LanguageTool 5.8                                                                                                                                                                                                                                       |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,27 +4,28 @@ services:
     image: meyay/languagetool:latest
     container_name: languagetool
     restart: unless-stopped
-    read_only: true
+    # read_only: true
     tmpfs:
       - /tmp
     cap_drop:
       - ALL
     cap_add:
+      - CAP_CHOWN
+      - CAP_DAC_OVERRIDE
       - CAP_SETUID
       - CAP_SETGID
-      - CAP_CHOWN
     security_opt:
       - no-new-privileges
     ports:
       # Using default port from the image
-      - 8010:8010
+      - 8081:8081
     environment:
       # OVERRIDE: comma seperated list of ngram language models to download (if not existing)
       #           Valid languages are "en", "de", "es", "fr" and "nl". Image default: none
       #           example: download_ngrams_for_langs: en,de,es
       download_ngrams_for_langs: en
       # OPTIONAL: container path for the ngrams data. Image default: /ngrams
-      #langtool_languageModel: /ngrams
+      # langtool_languageModel: /ngrams
       # OVERRIDE: container path to the fasttext binary. Image default: /usr/local/bin/fasttext
       # langtool_fasttextBinary: /usr/local/bin/fasttext
       # OPTIONAL: path to the fasttext model. Image default:/fasttext/lid.176.bin
@@ -44,9 +45,11 @@ services:
       # MAP_UID: 1026
       # OVERRIDE: Set GID for group languagetool. Image default: 783
       # MAP_GID: 100
-      #
-      # DISABLE_PERMISSION_FIX: false
+      # OPTIONAL: disable fixing file owner issues. Image default: false
+      # DISABLE_FILE_OWNER_FIX: false
+      # OPTIONAL: disable the fasttext support. Image default: false
       # DISABLE_FASTTEXT: false
+      # OPTIONAL: activate debug output for the entrypoint script. Image default: false
       # DEBUG_ENTRYPOINT: false
     volumes:
       # OPTIONAL: The location of ngrams data on the local machine

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,6 +30,10 @@ is_root() {
   [[ $(id -u) -eq 0 ]]
 }
 
+is_ro_mount(){
+  [[ "$(awk '/^[[:alnum:]]* \/ /{ split($4,mount_opts,","); for (i = 1; i <= length(mount_opts); i++){if (mount_opts[i] == "ro" || mount_opts[i] == "rw" ){print mount_opts[i];}}}' /proc/mounts)" == "ro" ]]
+}
+
 download_and_extract_ngram_language_model(){
   is_debug && set -x
 
@@ -48,23 +52,24 @@ download_and_extract_ngram_language_model(){
 
   if [[ ! -d "${langtool_languageModel}/${_LANG}" ]]; then
     if [[ ! -e "${langtool_languageModel}/ngrams-${_LANG}.zip" ]] || ! unzip -t "${langtool_languageModel}/ngrams-${_LANG}.zip" > /dev/null 2>&1; then
-      echo "INFO: Downloading \"${_LANG}\" ngrams."
+      echo -e "${INFO}: Downloading \"${_LANG}\" ngrams."
       wget -O "${langtool_languageModel}/ngrams-${_LANG}.zip" "${_BASE_URL}/${ngrams_filesnames[${_LANG}]}" || {
-        echo "ERROR: Failed to download ngrams for language ${lang}."
+        echo -e "${ERROR}: Failed to download ngrams for language ${lang}."
+        rm -f "${langtool_languageModel}/ngrams-${_LANG}.zip"
         exit 1
       }
     fi
     if [[ -e "${langtool_languageModel}/ngrams-${_LANG}.zip" ]]; then
-      echo "INFO: Extracting \"${_LANG}\" ngram language model."
+      echo -e "${INFO}: Extracting \"${_LANG}\" ngram language model."
       unzip "${langtool_languageModel}/ngrams-${_LANG}.zip" -d "${langtool_languageModel}" || {
-        echo "ERROR: Failed to extract ngrams for language ${lang}."
-        rm "${langtool_languageModel}/ngrams-${_LANG}.zip"
+        echo -e "${ERROR}: Failed to extract ngrams for language ${lang}."
+        rm -f "${langtool_languageModel}/ngrams-${_LANG}.zip"
         exit 1
       }
-      rm "${langtool_languageModel}/ngrams-${_LANG}.zip"
+      rm -f "${langtool_languageModel}/ngrams-${_LANG}.zip"
     fi
   else
-    echo "INFO: Skipping download of ngram model for language ${_LANG}: already exists."
+    echo -e "${INFO}: Skipping download of ngram model for language ${_LANG}: already exists."
   fi
 }
 # Export the function so it's available to the new shell
@@ -73,20 +78,39 @@ export -f download_and_extract_ngram_language_model
 handle_ngram_language_models(){
   is_debug && set -x
 
-  if [[ -z "${langtool_languageModel}" ]]; then
-     echo "ERROR: No base path for ngram language models provided. Language Tool will not download or use any ngram models."
+  # do not download ngram models
+  if [[ -z "${download_ngrams_for_langs}" ]] || [[ "${download_ngrams_for_langs}" == "none" ]] ; then
+   echo -e "${WARN}: \"download_ngrams_for_langs\" not provided, no ngrams will be downloaded."
+   return
   fi
-  dir_uid=$( stat -c '%u' "${langtool_languageModel}")
+
+  # no download folder provided
+  if [[ -z "${langtool_languageModel}" ]]; then
+     echo -e "${ERROR}: No base path for ngram language models provided. Language Tool will not download ngram models. It will only use existing ngram models."
+     return
+  fi
+
+  dir_uid=$( stat -c '%u' "${langtool_languageModel}" 2> /dev/null)
   actual_uid=$(id -u)
-  if [[ "${dir_uid}" == "${actual_uid}" ]];then
-     echo "INFO: directory ${langtool_languageModel} is owned by ${dir_uid}."
-  else
-     echo "ERROR: directory ${langtool_languageModel} is owned by ${dir_uid}, but should be owned by ${actual_uid}."
+  dir_gid=$( stat -c '%g' "${langtool_languageModel}" 2> /dev/null)
+  actual_gid=$(id -g)
+
+  # download folder not owned by user or group id
+  can_write=true
+  if [[ ! -x "${langtool_languageModel}" ]] && [[ ! -w "${langtool_languageModel}" ]];then
+    echo -e "${ERROR}: Directory \"${langtool_languageModel}\" does not allow the user or group to enter it or write into it."
+    can_write=false
+  fi
+
+  if [[ "${dir_uid}" != "${actual_uid}" ]] && [[ "${dir_gid}" != "${actual_gid}" ]] ;then
+    echo -e "${ERROR}: Directory \"${langtool_languageModel}\" is owned by ${dir_uid}:${dir_gid}, but should be owned by uid ${actual_uid} and/or gid ${actual_gid}."
+    can_write=false
+  fi
+  if [[ "${can_write}" == "false" ]]; then
      exit 1
   fi
-  if [[ -z "${download_ngrams_for_langs}" ]]; then
-      echo "WARNING: download_ngrams_for_langs not provided, no ngrams will be downloaded."
-  fi
+
+  echo -e "${INFO}: Directory ${langtool_languageModel} is owned by ${dir_uid}:${dir_gid}"
   IFS=',' read -ra langs <<< "${download_ngrams_for_langs}"
   for lang in "${langs[@]}"; do
     case "${lang}" in
@@ -96,7 +120,7 @@ handle_ngram_language_models(){
       none)
         ;;
       *)
-        echo "ERROR: Unknown ngrams language. Supported languages are \"en\", \"de\", \"es\", \"fr\" and \"nl\"."
+        echo -e "${ERROR}: Unknown ngrams language. Supported languages are \"en\", \"de\", \"es\", \"fr\" and \"nl\"."
         exit 1
     esac
   done
@@ -108,32 +132,37 @@ download_fasttext_model(){
   is_debug && set -x
 
   if [[ -z "${langtool_fasttextModel}" ]] || [[ "${DISABLE_FASTTEXT}" == "true" ]]; then
-      echo "INFO: \"langtool_fasttextModel\" not specified or \"DISABLE_FASTTEXT\" is set to \"true\". Skipping download of fasttext model."
+      echo -e "${INFO}: \"langtool_fasttextModel\" not specified or \"DISABLE_FASTTEXT\" is set to \"true\". Skipping download of fasttext model."
       unset langtool_fasttextModel
       return
   fi
 
+  # download folder not owned by user or group id
+  dir_uid=$(stat -c '%u' "${langtool_fasttextModel%/*}" 2> /dev/null)
+  actual_uid=$(id -u)
+  dir_gid=$(stat -c '%g' "${langtool_fasttextModel%/*}" 2> /dev/null)
+  actual_gid=$(id -g)
+
+  can_write=true
+  if [[ ! -x "${langtool_fasttextModel%/*}" ]] && [[ ! -w "${langtool_fasttextModel%/*}" ]];then
+    echo -e "${ERROR}: Directory \"${langtool_fasttextModel%/*}\" does not allow the user or group to enter it or write into it."
+    can_write=false
+  fi
+
+  if [[ "${dir_uid}" != "${actual_uid}" ]] && [[ "${dir_gid}" != "${actual_gid}" ]] ;then
+    echo -e "${ERROR}: Directory \"${langtool_fasttextModel%/*}\" is owned by ${dir_uid}:${dir_gid}, but should be owned by uid ${actual_uid} and/or gid ${actual_gid}."
+    can_write=false
+  fi
+  if [[ "${can_write}" == "false" ]]; then
+     exit 1
+  fi
+
+  echo -e "${INFO}: Directory ${langtool_fasttextModel%/*} is owned by ${dir_uid}:${dir_gid}."
   if [[ ! -e "${langtool_fasttextModel}" ]]; then
-    dir_uid=$( stat -c '%u' "${langtool_fasttextModel%/*}")
-    actual_uid=$(id -u)
-    if [[ "${dir_uid}" == "${actual_uid}" ]];then
-       echo "Info: directory ${langtool_fasttextModel%/*} is owned by ${dir_uid}."
-    else
-       echo "ERROR: directory ${langtool_fasttextModel%/*} is owned by ${dir_uid}, but should be owned by ${actual_uid}."
-       exit 1
-    fi
-    echo "INFO: Downloading fasttext model."
+    echo -e "${INFO}: Downloading fasttext model."
     wget  -O "${langtool_fasttextModel}" "https://dl.fbaipublicfiles.com/fasttext/supervised-models/lid.176.bin"
   else
-    echo "INFO: Skipping download of fasttext model: already exists."
-    file_uid=$( stat -c '%u' "${langtool_fasttextModel}")
-    actual_uid=$(id -u)
-    if [[ "${file_uid}" == "${actual_uid}" ]];then
-       echo "INFO: file ${langtool_fasttextModel} is owned by userid ${file_uid}."
-    else
-       echo "ERROR: file ${langtool_fasttextModel} is owned by ${file_uid}, but should be owned by ${actual_uid}."
-       exit 1
-    fi
+    echo -e "${INFO}: Skipping download of fasttext model: already exists."
   fi
 }
 # Export the function so it's available to the new shell
@@ -142,24 +171,23 @@ export -f download_fasttext_model
 fix_dir_owner(){
   local _PATH
   _PATH="${1}"
-  if [ -x "${_PATH}" ] ; then
-    find "${_PATH}"  ! \( -user  languagetool -group languagetool \) -exec chown languagetool:languagetool {} \;
+  if [[ -x "${_PATH}" ]]; then
+    find "${_PATH}"  ! \( -user  "languagetool" -group "languagetool" \) -exec chown "languagetool:languagetool" {} \;
   else
     cat << EOF
-WARN: permissions of directory "${_PATH}" prevents operation.
-  If this is intentional, please set environment variable DISABLE_PERMISSION_FIX to true to disable this feature.
-  If not run "sudo chmod o+x,o+r -R {path}" (replace {path} with your real host path!)
+$(echo -e "${WARN}"): permissions on "${_PATH}" do not allow to fix ownership.
+      If this is intentional, please set environment variable DISABLE_PERMISSION_FIX to true to disable this feature.
 EOF
   fi
 }
 
 fix_ownership(){
   if [[ -n "${langtool_languageModel}" ]]; then
-    echo "INFO: Fixing ownership for ngrams base folder if necessary."
+    echo -e "${INFO}: Fixing ownership for ngrams base folder if necessary."
     fix_dir_owner "${langtool_languageModel}"
   fi
   if [[ -n "${langtool_fasttextModel}" ]]; then
-    echo "INFO: Fixing ownership for fasttext model file if necessary."
+    echo -e "${INFO}: Fixing ownership for fasttext model file if necessary."
     fix_dir_owner "$(dirname "${langtool_fasttextModel}")"
   fi
 }
@@ -167,7 +195,7 @@ fix_ownership(){
 create_config(){
   local _config_file="${1}"
 
-  echo "INFO: Creating new LanguageTool config file."
+  echo -e "${INFO}: Creating new LanguageTool config file."
   if [[ -e "${_config_file}" ]]; then
     rm "${_config_file}"
     touch "${_config_file}"
@@ -175,7 +203,7 @@ create_config(){
 
   for varname in ${!langtool_*}; do
     config_injected=true
-    echo "${varname#'langtool_'}=${!varname}" >> "${_config_file}"
+    echo -e "${varname#'langtool_'}=${!varname}" >> "${_config_file}"
   done
 }
 
@@ -183,59 +211,158 @@ user_map(){
   if [[ -n "${MAP_UID}" ]]; then
     CURRENT_UID="$(id languagetool -u)"
     if [[ "${MAP_UID}" != "${CURRENT_UID}" ]]; then
-      echo "INFO: Setting uid for user \"languagetool\" to ${MAP_UID}."
+      echo -e "${INFO}: Setting uid for user \"languagetool\" to ${MAP_UID}."
       usermod -u "${MAP_UID}" languagetool
     fi
   fi
   if [[ -n "${MAP_GID}" ]]; then
     CURRENT_GID="$(id languagetool -g)"
     if [[ "${MAP_GID}" != "${CURRENT_GID}" ]]; then
-      echo "INFO: Setting gid for group \"languagetool\" to ${MAP_GID}."
-      groupmod -g "${MAP_GID}" languagetool
+      EXISTING_GROUP=$(getent group ${MAP_GID} | cut -d: -f1) || true
+      if [[ -n "${EXISTING_GROUP}" ]]; then
+        echo -e "${INFO}: Group \"${EXISTING_GROUP}\" already exists with gid ${MAP_GID}."
+        echo -e "${INFO}: Setting primary gid for user \"languagetool\" from ${CURRENT_GID} to ${MAP_GID}."
+        usermod -g "${MAP_GID}" languagetool
+      else
+        echo -e "${INFO}: Changing gid of group \"languagetool\" to gid ${MAP_GID}."
+        groupmod -g "${MAP_GID}" languagetool
+      fi
     fi
   fi
 }
 
 print_info(){
-  echo "INFO: Version Information:"
+  echo -e "${INFO}: Version Information:"
   local _ALPINE_VERSION
   _ALPINE_VERSION=$(grep "VERSION_ID=" /etc/os-release | cut -d'=' -f2)
-  echo "Alpine Linux v${_ALPINE_VERSION}" | indent
+  echo -e "Alpine Linux v${_ALPINE_VERSION}" | indent
   java --version | indent
 }
 
 indent() { sed 's/^/  /'; }
 
+is_cap_enabled() {
+    local _CHECK_CAP="${1}"
+
+    caps=$(awk '/^CapPrm:/ {print $2}' /proc/self/status)
+
+    # Convert hex to decimal
+    caps=$((16#$caps))
+
+    case "${_CHECK_CAP}" in
+      CAP_CHOWN)  [[ $((caps & 1)) -ne 0 ]]
+                  ;;
+      CAP_DAC_OVERRIDE) [[ $((caps & 2)) -ne 0 ]]
+                  ;;
+      CAP_DAC_READ_SEARCH) [[ $((caps & 4)) -ne 0 ]]
+                  ;;
+      CAP_FOWNER) [[ $((caps & 8)) -ne 0 ]]
+                  ;;
+      CAP_SETUID) [[ $((caps & 64)) -ne 0 ]]
+                  ;;
+      CAP_SETGID) [[ $((caps & 128)) -ne 0 ]]
+                  ;;
+    esac
+}
+
+print_capability_status() {
+    if [ "$1" = true ]; then
+        echo -e "${GREEN}yes${NC}"
+    else
+        echo -e "${RED}no${NC}"
+    fi
+}
+
 # main
 print_lt_help "$@"
 
-# actions that require root user and permission fixes
-if is_root  && [[ "${DISABLE_PERMISSION_FIX}" != "true" ]]; then
-  user_map
-  fix_ownership
-else
-  if is_root; then
-    EXPECTED_IDS="${MAP_UID}:${MAP_GID}"
-  else
-    EXPECTED_IDS="$(id -u):$(id -g)"
+# Define color codes. Note: export is to required to work with "su -m"
+export GREEN='\033[0;32m'
+export RED='\033[0;31m'
+export ORANGE='\033[0;33m'
+export NC='\033[0m' # No Color
+
+# Define colored output. Note: export is to required to work with "su -m"
+export INFO="${GREEN}INFO${NC}"
+export WARN="${ORANGE}WARN${NC}"
+export ERROR="${RED}ERROR${NC}"
+
+if is_root; then
+
+  EXPECTED_IDS="${MAP_UID}:${MAP_GID}"
+  OWNER_FIX=true
+  USER_MAPPING=true
+
+  echo -e "${INFO}: Container started as root user."
+  echo -e "${INFO}: Available capabilities:"
+  echo -e "  CAP_CHOWN         Can change owner of files and directories: $(is_cap_enabled CAP_CHOWN && print_capability_status true || print_capability_status false)"
+  echo -e "  CAP_DAC_OVERRIDE  Can bypass file permission checks when changing owner: $(is_cap_enabled CAP_DAC_OVERRIDE  && print_capability_status true || print_capability_status false)"
+  echo -e "  CAP_SETUID        Can execute languagetool with arbitrary uid: $(is_cap_enabled CAP_SETUID && print_capability_status true || print_capability_status false)"
+  echo -e "  CAP_SETGUID       Can execute languagetool with arbitrary gid: $(is_cap_enabled CAP_SETGID && print_capability_status true || print_capability_status false)"
+
+  if is_ro_mount "/"; then
+     echo -e "${INFO}: Container started with readonly filesystem."
+     USE_NSS_WRAPPER=false
+     if [[ -n "${MAP_UID}" ]]; then
+       CURRENT_UID="$(id languagetool -u)"
+        if [[ "${MAP_UID}" != "${CURRENT_UID}" ]]; then
+          USE_NSS_WRAPPER=true
+        fi
+     fi
+    if [[ -n "${MAP_GID}" ]]; then
+      CURRENT_GID="$(id languagetool -g)"
+      if [[ "${MAP_GID}" != "${CURRENT_GID}" ]]; then
+          USE_NSS_WRAPPER=true
+      fi
+    fi
+    if [[ "${USE_NSS_WRAPPER}" == "true" ]]; then
+   		export LD_PRELOAD='/usr/lib/libnss_wrapper.so'
+   		export NSS_WRAPPER_PASSWD="$(mktemp)"
+   		export NSS_WRAPPER_GROUP="$(mktemp)"
+
+      echo "languagetool:x:${MAP_UID}:${MAP_GID}:languagetool gecos:/home/languagetool:/sbin/nologin" > "${NSS_WRAPPER_PASSWD}"
+   		echo "languagetool:x:${MAP_GID}:" > "${NSS_WRAPPER_GROUP}"
+
+   		chmod +r "${NSS_WRAPPER_PASSWD}"
+   		chmod +r "${NSS_WRAPPER_GROUP}"
+
+   		echo -e "${INFO}: using nss_wrapper to set uid for user \"languagetool\" to ${MAP_UID} and gid for group \"languagetool\" to ${MAP_GID}."
+    fi
   fi
-  cat << EOF
-INFO: Container started as UID:GID $(id -u):$(id -g) with DISABLE_PERMISSION_FIX=${DISABLE_PERMISSION_FIX}.
+  if [[ "${DISABLE_FILE_OWNER_FIX}" == "true" ]]; then
+    OWNER_FIX=false
+    echo -e "${INFO}: Container started with DISABLE_FILE_OWNER_FIX=${DISABLE_FILE_OWNER_FIX}. This disables the ownership fix of directories."
+  fi
+  if [[ "${USER_MAPPING}" == "true" ]] && [[ "${USE_NSS_WRAPPER}" != "true" ]]; then
+    user_map
+  fi
+  if [[ "${OWNER_FIX}" == "true" ]] && is_cap_enabled "CAP_CHOWN" && is_cap_enabled "CAP_DAC_OVERRIDE"; then
+    fix_ownership
+  else
+    echo -e "${WARN}: Container started without sufficient capabilities to fix ownership of directories."
+    echo -e "  Make sure the volumes have have the correct permissions and are owned by ${EXPECTED_IDS}."
+  fi
 
-- Usermapping is not available. Make sure your volumes are owned by that user!
-- Ownership of directory can not be fixed. Makes sure your volume have the correct permissions set and are owned by ${EXPECTED_IDS}.
-
-EOF
+else
+  EXPECTED_IDS="$(id -u):$(id -g)"
+  echo -e "${INFO}: Container started as unprivileged UID:GID ${EXPECTED_IDS}. Skipping User mapping."
+  echo -e "      Make sure the volumes have have the correct permissions and are owned by ${EXPECTED_IDS}."
 fi
 
-# download ngram models and fasttext model as user
-if is_root; then
-  su -s /bin/bash languagetool -c 'handle_ngram_language_models'
-  su -s /bin/bash languagetool -c 'download_fasttext_model'
+# download ngram models and fasttext model as MAP_UID:MAP_GID user
+if [[ "${USER_MAPPING}" == "true" ]]; then
+    su -m -s /bin/bash languagetool -c 'handle_ngram_language_models'
+    su -m -s /bin/bash languagetool -c 'download_fasttext_model'
+    if [[ "${DISABLE_FASTTEXT}" == "true" ]]; then
+      unset langtool_fasttextModel
+    fi
+
 else
-  DISABLE_PERMISSION_FIX=false
-  handle_ngram_language_models
-  download_fasttext_model
+    handle_ngram_language_models
+    download_fasttext_model
+    if [[ "${DISABLE_FASTTEXT}" == "true" ]]; then
+      unset langtool_fasttextModel
+    fi
 fi
 
 # create config
@@ -246,14 +373,14 @@ print_info
 
 # show current languagetool config
 if [[ "$config_injected" = true ]]; then
-  echo 'INFO: Using following LanguageTool configuration:'
+  echo -e "${INFO}: Using following LanguageTool configuration:"
   indent < "${CONFIG_FILE}"
 fi
 
 # set default JAVA_OPTS with default memory limits and garbage collector
 if [[ -z "${JAVA_OPTS}" ]]; then
   JAVA_GC="${JAVA_GC:-ShenandoahGC}"
-  for gc in SerialGC ParallelGC ParNewGC G1GC ZGC ShenandoahGC; do
+  for gc in ShenandoahGC SerialGC ParallelGC ParNewGC G1GC ZGC; do
     if [[ "${JAVA_GC}" == "${gc}" ]]; then
       JAVA_GC_OPT="-XX:+Use${JAVA_GC}"
       if [[ "${JAVA_GC}" == "G1GC" ]]; then
@@ -263,10 +390,10 @@ if [[ -z "${JAVA_OPTS}" ]]; then
     fi
   done
   JAVA_OPTS="-Xms${JAVA_XMS:-256m} -Xmx${JAVA_XMX:-1536m} ${JAVA_GC_OPT}"
-  echo "INFO: Using JAVA_OPTS=${JAVA_OPTS}"
+  echo -e "${INFO}: Using JAVA_OPTS=${JAVA_OPTS}"
 else
-  echo "JAVA_OPTS environment variables detected."
-  echo "INFO: Using JAVA_OPTS=${JAVA_OPTS}"
+  echo -e "JAVA_OPTS environment variables detected."
+  echo -e "${INFO}: Using JAVA_OPTS=${JAVA_OPTS}"
 fi
 
 read -ra FINAL_JAVA_OPTS <<< "${JAVA_OPTS}"
@@ -276,8 +403,9 @@ cp "${LOGBACK_CONFIG}" /tmp/logback.xml
 xml edit --inplace --update "/configuration/logger[@name='org.languagetool']/@level" --value "${LOG_LEVEL}" /tmp/logback.xml
 
 if [[ $# -gt 0 ]] && [[ "$1" != "help" ]]; then
+  unset RED GREEN ORANGE NC INFO WARN ERROR
   if is_root; then
-    exec su-exec languagetool:languagetool "$@"
+    su-exec "${MAP_UID}:${MAP_GID}" "$@"
   else
     exec "$@"
   fi
@@ -285,18 +413,23 @@ if [[ $# -gt 0 ]] && [[ "$1" != "help" ]]; then
 fi
 
 # start languagetool
-echo "INFO: StartingLanguage Tool Standalone Server (or custom command)"
+echo -e "${INFO}: StartingLanguage Tool Standalone Server (or custom command)"
+echo "--------------------------------------------------------------------"
+
+# cleanup variables
+unset RED GREEN ORANGE NC INFO WARN ERROR
+
 if is_root; then
-  EXECUTE_ARGS="su-exec languagetool:languagetool"
+  EXECUTE_ARGS="su-exec ${MAP_UID}:${MAP_GID}"
 else
-  EXECUTE_ARGS=""
+  EXECUTE_ARGS="exec"
 fi
 
 read -ra FINAL_EXECUTE_ARGS <<< "${EXECUTE_ARGS}"
 
-exec "${FINAL_EXECUTE_ARGS[@]}" \
+"${FINAL_EXECUTE_ARGS[@]}" \
     java "${FINAL_JAVA_OPTS[@]}" -Dlogback.configurationFile="/tmp/logback.xml" -cp languagetool-server.jar org.languagetool.server.HTTPServer \
-      --port "${LISTEPORT:-8010}" \
+      --port "${LISTEN_PORT:-8081}" \
       --public \
       --allow-origin "*" \
       --config /tmp/config.properties


### PR DESCRIPTION
>⚠️ BREAKING CHANGE in version 6.6-0 ⚠️
>
>The default listen port inside the container has changed:
>- Previous versions: port 8010
>- New version (6.6-0): port 8081
>
>Either update your port mapping configuration to use the new port, or set the environment
>variable `LISTEN_PORT` to `8010` to retain old behavior.

- fix: change default port inside the image from 8010 to 8081 (which is the default lt server port)
- chore: upgrade to Java 21.0.7+6
- chore: upgrade Dockerfile.fasttext base image to 3.18.12
- feat: container now fully support read-only filesystem
- feat: nss_wrapper is used for user mapping if read-only filesystem is used
- feat: check availability of capabilites
- fix: corrected env name `DISABLE_PERMISSION_FIX` to `DISABLE_FILE_OWNER_FIX` as it only fixes file ownership