### PR TITLE
chore: patch fasttext to support gcc13

### DIFF
--- a/Dockerfile.fasttext
+++ b/Dockerfile.fasttext
@@ -1,6 +1,6 @@
 ARG LT_VERSION=6.6
 ARG JAVA_VERSION=jdk-21.0.7+6
-FROM alpine:3.18.12 as base
+FROM alpine:3.21.3 AS base
 
 FROM base AS java_base
 
@@ -82,12 +82,17 @@ FROM base AS fasttext
 SHELL ["/bin/sh", "-o", "pipefail", "-c"]
 
 RUN set -eux; \
-    apk add --no-cache git build-base upx; \
+    apk add --no-cache git build-base cmake upx; \
     rm -rf /var/cache/apk/*
 
+COPY patches/ /patches/
 RUN set -eux; \
     git clone https://github.com/facebookresearch/fastText.git; \
-    make -C fastText;\
+    cp /patches/* fastText/; \
+    cd fastText; \
+    git apply gcc13.patch; \
+    cmake . ; \
+    make ; \
     upx -5 -o /fastText/fasttext-upx /fastText/fasttext
 
 FROM java_base

--- a/README.md
+++ b/README.md
@@ -214,9 +214,11 @@ cd docker-languagetool
 sudo docker build -t meyay/languagetool:latest -f Dockerfile.fasttext .
 ```
 
+As alternative method, `sudo make docker_build` can be used to build your custom image.
+
 Once the image is build, you can `docker compose up -d` like you would do with the images hosted on Docker Hub.
 
->NOTE1: Alpine version 3.19+ comes with gcc13, and does not provide older versions which are required to compile the fasttext sources. As a result Alpine 3.18.8 is used to compile fasttext with gcc12.
+>NOTE1: From now on the fastText sources are patched to work with gcc13.
 
 >NOTE2: Synology users can find a git package in the [SynoCommunity](https://synocommunity.com) repository.
 

--- a/patches/gcc13.patch
+++ b/patches/gcc13.patch
@@ -1,0 +1,12 @@
+diff --git a/src/args.h b/src/args.h
+index 3e04d6c..1cbe1dc 100644
+--- a/src/args.h
++++ b/src/args.h
+@@ -8,6 +8,7 @@
+
+ #pragma once
+
++#include <cstdint>
+ #include <istream>
+ #include <ostream>
+ #include <string>


### PR DESCRIPTION
- patch fastText sources to work with gcc13 provided by Alpine 3.19+