### PR TITLE
feat: Silence wget unless `is_debug` is set

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,6 +41,10 @@ download_and_extract_ngram_language_model(){
   _LANG="${1}"
   local _BASE_URL
   _BASE_URL="https://languagetool.org/download/ngram-data"
+  local _WGET_QUIET
+  _WGET_QUIET="--quiet"
+
+  [ -n "$is_debug" ] && _WGET_QUIET=""
 
   # mapping for ngram language models
   declare -A ngrams_filesnames
@@ -53,7 +57,7 @@ download_and_extract_ngram_language_model(){
   if [[ ! -d "${langtool_languageModel}/${_LANG}" ]]; then
     if [[ ! -e "${langtool_languageModel}/ngrams-${_LANG}.zip" ]] || ! 7z t "${langtool_languageModel}/ngrams-${_LANG}.zip" -bb0 > /dev/null 2>&1; then
       echo -e "${INFO}: Downloading \"${_LANG}\" ngrams."
-      wget -O "${langtool_languageModel}/ngrams-${_LANG}.zip" "${_BASE_URL}/${ngrams_filesnames[${_LANG}]}" || {
+      wget "${_WGET_QUIET}" -O "${langtool_languageModel}/ngrams-${_LANG}.zip" "${_BASE_URL}/${ngrams_filesnames[${_LANG}]}" || {
         echo -e "${ERROR}: Failed to download ngrams for language ${_LANG}."
         rm -f "${langtool_languageModel}/ngrams-${_LANG}.zip"
         exit 1
@@ -131,6 +135,11 @@ export -f handle_ngram_language_models
 download_fasttext_model(){
   is_debug && set -x
 
+  local _WGET_QUIET
+  _WGET_QUIET="--quiet"
+
+  [ -n "$is_debug" ] && _WGET_QUIET=""
+
   if [[ -z "${langtool_fasttextModel}" ]] || [[ "${DISABLE_FASTTEXT}" == "true" ]]; then
       echo -e "${INFO}: \"langtool_fasttextModel\" not specified or \"DISABLE_FASTTEXT\" is set to \"true\". Skipping download of fasttext model."
       unset langtool_fasttextModel
@@ -160,7 +169,7 @@ download_fasttext_model(){
   echo -e "${INFO}: Directory ${langtool_fasttextModel%/*} is owned by ${dir_uid}:${dir_gid}."
   if [[ ! -e "${langtool_fasttextModel}" ]]; then
     echo -e "${INFO}: Downloading fasttext model."
-    wget  -O "${langtool_fasttextModel}" "https://dl.fbaipublicfiles.com/fasttext/supervised-models/lid.176.bin"
+    wget "${_WGET_QUIET}" -O "${langtool_fasttextModel}" "https://dl.fbaipublicfiles.com/fasttext/supervised-models/lid.176.bin"
   else
     echo -e "${INFO}: Skipping download of fasttext model: already exists."
   fi


### PR DESCRIPTION
`wget` spams the docker logs with one line per second for ngram and model downloads.
This patch passes `--quiet` to `wget` invocations in `entrypoint.sh`, unless `is_debug` is set to any value.

```
INFO: Downloading "en" ngrams.
Connecting to languagetool.org (172.64.151.199:443)
saving to '/ngrams/ngrams-en.zip' 
ngrams-en.zip          0% |                                |  979k  2:31:55 ETA
ngrams-en.zip          0% |                                | 12.5M  0:22:45 ETA 
ngrams-en.zip          0% |                                | 23.3M  0:18:16 ETA
ngrams-en.zip          0% |                                | 34.5M  0:16:26 ETA
```