### PR TITLE
Add ARM64 multi-arch build and release support

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -53,6 +53,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
@@ -73,7 +76,7 @@ jobs:
         id: gather_build_args
         # language="Shell Script"
         run: |
-          LT_VERSION=$(grep '^ARG LT_VERSION=' Dockerfile | cut -d'=' -f2)
+          LT_VERSION=$(grep '^ARG LT_VERSION=' Dockerfile | cut -d'=' -f2 | tr -d '"')
           TAGS=$(gh api repos/${{ github.repository }}/tags --jq '.[].name' || echo "")
           MAX_VERSION=-1
           for tag in $TAGS; do
@@ -97,7 +100,7 @@ jobs:
           pull: true
           push: true
           tags: ghcr.io/meyayl/languagetool:${{ github.run_id }}
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
@@ -163,6 +166,61 @@ jobs:
             http://127.0.0.1:8081/v2/check | tee /dev/stderr | grep -q detectedLanguage
           echo "🛑 Stopping container..."
           docker compose down
+
+  integration-test-image-arm64-smoke:
+    name: Integration test Image ARM64 smoke
+    needs: [ build-test-image ]
+    runs-on: ubuntu-latest
+
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.job }}-arm64-smoke-${{ github.ref }}
+      cancel-in-progress: true
+
+    permissions:
+      packages: read
+
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run ARM64 smoke test
+        # language="Shell Script"
+        run: |
+          set -euxo pipefail
+          cleanup() {
+            docker rm -f languagetool-arm64 >/dev/null 2>&1 || true
+          }
+          dump_logs() {
+            docker logs languagetool-arm64 || true
+          }
+          trap cleanup EXIT
+          trap dump_logs ERR
+          docker run --detach \
+            --name languagetool-arm64 \
+            --platform linux/arm64 \
+            --publish 8081:8081 \
+            --tmpfs /tmp:exec \
+            --env DISABLE_FILE_OWNER_FIX=true \
+            ghcr.io/meyayl/languagetool:${{ github.run_id }}
+          for _ in $(seq 1 90); do
+            if curl --fail --silent --show-error http://127.0.0.1:8081/v2/healthcheck > /dev/null; then
+              break
+            fi
+            sleep 2
+          done
+          curl --fail --silent --show-error http://127.0.0.1:8081/v2/healthcheck > /dev/null
+          docker exec languagetool-arm64 /opt/java/customjre/bin/java --version
+          docker exec languagetool-arm64 test -s /fasttext/lid.176.bin
+          curl --data "language=en-US&text=a simple test" \
+            http://127.0.0.1:8081/v2/check | tee /dev/stderr | grep -q detectedLanguage
+
   scan-image:
     name: Scan Image with Grype
     needs: [ build-test-image ]
@@ -202,7 +260,7 @@ jobs:
 
   update-pr:
     name: Update PullRequest
-    needs: [ build-test-image, integration-test-image, scan-image ]
+    needs: [ build-test-image, integration-test-image, integration-test-image-arm64-smoke, scan-image ]
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
 
@@ -279,7 +337,7 @@ jobs:
 
   retag-and-push-final-image:
     name: Retag and push final image
-    needs: [ build-test-image, integration-test-image, cve-check-image-and-report ]
+    needs: [ build-test-image, integration-test-image, integration-test-image-arm64-smoke, cve-check-image-and-report ]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
 
@@ -287,6 +345,9 @@ jobs:
       packages: read
 
     steps:
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       - name: Login to Docker Hub
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
@@ -305,22 +366,19 @@ jobs:
         id: image_tags
         # language="Shell Script"
         run: |
-          LT_VERSION=$(grep '^ARG LT_VERSION=' Dockerfile | cut -d'=' -f2)
           IMAGE_VERSION=${GITHUB_REF#refs/tags/}
-          echo "IMAGE_VERSION=${LT_VERSION}-${IMAGE_VERSION}" >> $GITHUB_OUTPUT
+          LT_VERSION=${IMAGE_VERSION%-*}
+          echo "IMAGE_VERSION=${IMAGE_VERSION}" >> $GITHUB_OUTPUT
           echo "LT_VERSION=${LT_VERSION}" >> $GITHUB_OUTPUT
-          GH_TOKEN: ${{ github.token }}
 
-      - name: Pull and retag image
+      - name: Publish multi-arch tags to Docker Hub
         # language="Shell Script"
-        run:
-          docker pull ghcr.io/meyayl/languagetool:${{ github.run_id }}
-          docker tag ghcr.io/meyayl/languagetool:${{ github.run_id }} meyay/languagetool:${{ steps.image_tags.outputs.IMAGE_VERSION }}
-          docker tag ghcr.io/meyayl/languagetool:${{ github.run_id }} meyay/languagetool:${{ steps.image_tags.outputs.LT_VERSION }}
-          docker tag ghcr.io/meyayl/languagetool:${{ github.run_id }} meyay/languagetool:latest
-          docker push meyay/languagetool:${{ steps.image_tags.outputs.IMAGE_VERSION }}
-          docker push meyay/languagetool:${{ steps.image_tags.outputs.LT_VERSION }}
-          docker push meyay/languagetool:latest
+        run: |
+          docker buildx imagetools create \
+            --tag meyay/languagetool:${{ steps.image_tags.outputs.IMAGE_VERSION }} \
+            --tag meyay/languagetool:${{ steps.image_tags.outputs.LT_VERSION }} \
+            --tag meyay/languagetool:latest \
+            ghcr.io/meyayl/languagetool:${{ github.run_id }}
 
       - name: Update repo description
         uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
@@ -181,7 +181,7 @@ jobs:
 
     steps:
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
 
       - name: Login to GHCR
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ SHELL ["/bin/sh", "-o", "pipefail", "-c"]
 ARG LT_VERSION
 ARG JAVA_VERSION
 ARG MAVEN_VERSION
+ARG TARGETARCH
 
 ENV JAVA_HOME=/opt/java/openjdk \
     JAVA_VERSION=${JAVA_VERSION}
@@ -56,11 +57,17 @@ RUN set -eux; \
 # hadolint ignore=SC3060
 # hadolint ignore=DL4006
 RUN set -eux; \
+        TARGET_ARCH_RAW="${TARGETARCH:-$(apk --print-arch)}"; \
+        case "${TARGET_ARCH_RAW}" in \
+            amd64|x86_64) JAVA_ARCH=x64 ;; \
+            arm64|aarch64) JAVA_ARCH=aarch64 ;; \
+            *) echo "Unsupported Java architecture: ${TARGET_ARCH_RAW}" >&2; exit 1 ;; \
+        esac; \
     RELEASE_PATH="${JAVA_VERSION/+/%2B}"; \
     RELEASE_TYPE="${JAVA_VERSION%-*}"; \
     RELEASE_NUMBER="${JAVA_VERSION#*-}"; \
     RELEASE_NUMBER="${RELEASE_NUMBER/+/_}"; \
-    URL="https://github.com/adoptium/temurin21-binaries/releases/download/${RELEASE_PATH}/OpenJDK21U-${RELEASE_TYPE}_x64_alpine-linux_hotspot_${RELEASE_NUMBER}.tar.gz"; \
+        URL="https://github.com/adoptium/temurin21-binaries/releases/download/${RELEASE_PATH}/OpenJDK21U-${RELEASE_TYPE}_${JAVA_ARCH}_alpine-linux_hotspot_${RELEASE_NUMBER}.tar.gz"; \
     CHKSUM=$(wget --quiet -O -  "${URL}.sha256.txt" | cut -d' ' -f1); \
     wget -O /tmp/openjdk.tar.gz ${URL}; \
     echo "${CHKSUM} */tmp/openjdk.tar.gz" | sha256sum -c -; \

--- a/Dockerfile.fasttext
+++ b/Dockerfile.fasttext
@@ -45,6 +45,7 @@ SHELL ["/bin/sh", "-o", "pipefail", "-c"]
 ARG LT_VERSION
 ARG JAVA_VERSION
 ARG MAVEN_VERSION
+ARG TARGETARCH
 
 ENV JAVA_HOME=/opt/java/openjdk \
     JAVA_VERSION=${JAVA_VERSION}
@@ -56,11 +57,17 @@ RUN set -eux; \
 # hadolint ignore=SC3060
 # hadolint ignore=DL4006
 RUN set -eux; \
+        TARGET_ARCH_RAW="${TARGETARCH:-$(apk --print-arch)}"; \
+        case "${TARGET_ARCH_RAW}" in \
+            amd64|x86_64) JAVA_ARCH=x64 ;; \
+            arm64|aarch64) JAVA_ARCH=aarch64 ;; \
+            *) echo "Unsupported Java architecture: ${TARGET_ARCH_RAW}" >&2; exit 1 ;; \
+        esac; \
     RELEASE_PATH="${JAVA_VERSION/+/%2B}"; \
     RELEASE_TYPE="${JAVA_VERSION%-*}"; \
     RELEASE_NUMBER="${JAVA_VERSION#*-}"; \
     RELEASE_NUMBER="${RELEASE_NUMBER/+/_}"; \
-    URL="https://github.com/adoptium/temurin21-binaries/releases/download/${RELEASE_PATH}/OpenJDK21U-${RELEASE_TYPE}_x64_alpine-linux_hotspot_${RELEASE_NUMBER}.tar.gz"; \
+        URL="https://github.com/adoptium/temurin21-binaries/releases/download/${RELEASE_PATH}/OpenJDK21U-${RELEASE_TYPE}_${JAVA_ARCH}_alpine-linux_hotspot_${RELEASE_NUMBER}.tar.gz"; \
     CHKSUM=$(wget --quiet -O -  "${URL}.sha256.txt" | cut -d' ' -f1); \
     wget -O /tmp/openjdk.tar.gz ${URL}; \
     echo "${CHKSUM} */tmp/openjdk.tar.gz" | sha256sum -c -; \
@@ -169,6 +176,7 @@ RUN set -eux; \
     git apply --stat gcc13.patch; \
     git apply --check gcc13.patch; \
     git apply gcc13.patch; \
+    sed -i 's/ -march=native//g' CMakeLists.txt Makefile setup.py; \
     cmake  -DCMAKE_POLICY_VERSION_MINIMUM=3.5 . ; \
     make ; \
     upx -5 -o /fastText/fasttext-upx /fastText/fasttext

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,15 @@ all: docker_build docker_compose
 docker_build:
 	@echo "Building container"
 	@sudo docker build -t meyay/languagetool:latest -f Dockerfile.fasttext .
+
+docker_build_arm64:
+	@echo "Building ARM64 container"
+	@sudo docker buildx build --platform linux/arm64 --load -t meyay/languagetool:arm64 .
+
+docker_build_fasttext_arm64:
+	@echo "Building ARM64 container with source-built fasttext"
+	@sudo docker buildx build --platform linux/arm64 --load -t meyay/languagetool:arm64-fasttext -f Dockerfile.fasttext .
+
 docker_compose:
 	@echo "Starting container"
 	@docker compose up -d

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The Docker Hub repository can be found [here](https://hub.docker.com/r/meyay/lan
 
 - Built directly from [LanguageTool repository tags](https://github.com/languagetool-org/languagetool/tags) since official release zips were [discontinued after v6.6](https://github.com/languagetool-org/languagetool/blob/master/languagetool-standalone/CHANGES.md#66-2025-03-27)
 - Built on latest Alpine 3.23 base image
+- Multi-architecture image support for `linux/amd64` and `linux/arm64`
 - Custom Eclipse Temurin 21 JRE (optimized with required modules only)
 - Uses `tini` to handle container signals properly
 - includes `fasttext`
@@ -41,6 +42,25 @@ The Docker Hub repository can be found [here](https://hub.docker.com/r/meyay/lan
 
 The following subsections show usage examples.<br/>
 An example compose file can be downloaded from [here](https://raw.githubusercontent.com/meyayl/docker-languagetool/main/docker-compose.yml).
+
+### Building for ARM64
+
+The published image is built for `linux/amd64` and `linux/arm64`.
+
+For local builds on an ARM64 host, plain `docker build` works for both Dockerfiles.
+If you are building from a non-ARM64 host, use Docker Buildx and set `--platform linux/arm64`.
+
+#### Default image
+
+```sh
+docker buildx build --platform linux/arm64 --load -t meyay/languagetool:arm64 .
+```
+
+#### fasttext-from-source image
+
+```sh
+docker buildx build --platform linux/arm64 --load -t meyay/languagetool:arm64-fasttext -f Dockerfile.fasttext .
+```
 
 ### Start container as root user with read-only filesystem, start LanguageTool as MAP_UID:MAP_GID
 
@@ -212,7 +232,7 @@ The environment parameters are split into two halves, separated by an equal or c
 
 Now that fasttext is available since Alpine 3.19, the image switched to using the Alpine package, instead of compiling the binaries from the sources. This hopefully fixes the compatibility issue users with older cpus experienced with my previous images, that were build on a amd64v3 architecture cpu, which compiled the `fasttext` binary with cpu optimizations older cpus do not support.
 
-If the Alpine `fasttext` package does not work for you, you can build a custom image to compile the `fasttext` binary using cpu optimizations your cpu (as long as it's x86_64 based) actually understands:
+If the Alpine `fasttext` package does not work for you, you can build a custom image that compiles the `fasttext` binary from source:
 
 ```
 git clone  https://github.com/meyayl/docker-languagetool.git
@@ -220,7 +240,13 @@ cd docker-languagetool
 sudo docker build -t meyay/languagetool:latest -f Dockerfile.fasttext .
 ```
 
-As alternative method, `sudo make docker_build` can be used to build your custom image.
+To build that variant for ARM64 from a non-ARM64 machine, use Buildx instead:
+
+```sh
+docker buildx build --platform linux/arm64 --load -t meyay/languagetool:arm64-fasttext -f Dockerfile.fasttext .
+```
+
+As alternative methods, `sudo make docker_build` and `sudo make docker_build_fasttext_arm64` can be used for the source-built image.
 
 Once the image is build, you can `docker compose up -d` like you would do with the images hosted on Docker Hub.
 


### PR DESCRIPTION
## Summary

- build and push `linux/amd64` and `linux/arm64` images to GHCR in CI
- add an ARM64 smoke test job and pin `docker/setup-qemu-action` to the immutable `v4.0.0` SHA
- preserve multi-arch manifests when publishing Docker Hub tags from GHCR
- make both Dockerfiles architecture-aware for Temurin downloads and remove `-march=native` from the source-built fastText variant
- add ARM64 Make targets and README build instructions

## Why

- the image pipeline was still publishing only `linux/amd64`
- retagging a pulled image would collapse a multi-arch release back to the runner architecture
- Temurin download asset names differ between `amd64` and `arm64`
- the source-built fastText variant should not depend on `-march=native`, which is less portable

## Details

- add `platforms: linux/amd64,linux/arm64` to the GHCR build step
- add a dedicated ARM64 smoke test job that boots the container under QEMU and checks health, Java, fastText, and the `/v2/check` API
- gate PR comment updates and tagged release publication on the new ARM64 smoke test
- switch Docker Hub publication to `docker buildx imagetools create` so the GHCR multi-arch manifest is preserved
- map Docker and BuildKit `TARGETARCH` values to the correct Temurin asset names in both Dockerfiles
- strip `-march=native` from the source-built fastText variant for better portability
- add ARM64 Buildx targets to the Makefile and document ARM64 builds in the README
- normalize quoted `LT_VERSION` parsing and derive `LT_VERSION` from the pushed tag in the release workflow

## Validation

- `docker buildx build --platform linux/arm64 --load -t meyay/languagetool:arm64-test .`
- VS Code workflow diagnostics report no errors in `.github/workflows/pipeline.yaml`
- `actionlint` could not be run locally because it is not installed in this environment

## Compatibility note

- `docker/setup-qemu-action@v4` uses Node 24
- GitHub-hosted `ubuntu-latest` runners are compatible
- self-hosted runners need Actions Runner `v2.327.1` or newer

### Disclaimer

AI (Copilot via GPT 5.4 xhigh) was used in the development of this feature.