### PR TITLE
fix(ci): add checkout to retag job and increase Claude max-turns to 10

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -371,6 +371,12 @@ jobs:
       packages: read
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
       - name: Login to Docker Hub
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
@@ -460,7 +466,7 @@ jobs:
             Output nothing else — no commentary, no explanation, just write the file and stop.
           claude_args: |
             --allowedTools Bash,Write,Read
-            --max-turns 5
+            --max-turns 10
 
       - name: Ensure release notes file exists
         # language="Shell Script"


### PR DESCRIPTION
- retag-and-push-final-image was missing a checkout step, causing peter-evans/dockerhub-description to fail with README.md not found
- generate-release-summary hit the 5-turn limit before writing release-notes.md; increased to 10