### PR TITLE
chore(deps): bump Go version to 1.26.4-alpine3.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Image tags follow the pattern `{LanguageTool_version}-{sequential_number}` (e.g.
 ### Changed
 
 - Upgrade Maven to 3.9.16
+- Upgrade Go to 1.26.4
 
 ## [6.8-2] - 2026-05-16
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG IMAGE_VERSION="6.8-1"
-ARG IMAGE_CREATED="2026-05-15"
+ARG IMAGE_VERSION="6.8-3"
+ARG IMAGE_CREATED="2026-06-05"
 # renovate: datasource=github-tags depName=languagetool-org/languagetool versioning=loose
 ARG LT_VERSION="6.8"
 # renovate: datasource=github-releases depName=adoptium/temurin21-binaries versioning=regex:^jdk-(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)\+(?<build>\d+)$

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG JAVA_VERSION="jdk-21.0.11+10"
 # renovate: datasource=github-releases depName=apache/maven versioning=semver extractVersion=^maven-(?<version>.*)$
 ARG MAVEN_VERSION="3.9.16"
 # renovate: datasource=docker depName=golang versioning=docker
-ARG GO_VERSION="1.26-alpine3.23"
+ARG GO_VERSION="1.26.4-alpine3.23"
 FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 AS base
 
 FROM base AS java_base

--- a/Dockerfile.fasttext
+++ b/Dockerfile.fasttext
@@ -1,5 +1,5 @@
-ARG IMAGE_VERSION="6.8-1"
-ARG IMAGE_CREATED="2026-05-15"
+ARG IMAGE_VERSION="6.8-3"
+ARG IMAGE_CREATED="2026-06-05"
 # renovate: datasource=github-tags depName=languagetool-org/languagetool versioning=loose
 ARG LT_VERSION="6.8"
 # renovate: datasource=github-releases depName=adoptium/temurin21-binaries versioning=regex:^jdk-(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)\+(?<build>\d+)$


### PR DESCRIPTION
## Summary

- Bumps `GO_VERSION` build arg in `Dockerfile` from `1.26-alpine3.23` to `1.26.4-alpine3.23`

## Test plan

- [ ] CI build-test-image passes
- [ ] Integration tests pass on amd64 and arm64

🤖 Generated with [Claude Code](https://claude.com/claude-code)