### PR TITLE
refactor(cve-patches): gate pom.xml patches to LT_VERSION and remove direct JAR replacements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Image tags follow the pattern `{LanguageTool_version}-{sequential_number}` (e.g. `6.8-3`).
 
-## [6.8-3] - 2026-05-18
+## [6.8-3] - 2026-06-05
 
 ### Changed
 
 - Upgrade Maven to 3.9.16
 - Upgrade Go to 1.26.4
+- Gate pom.xml CVE patches to LT_VERSION 6.8 only
+- Remove direct netty JAR replacements from build
+
+### Security
+
+- Patch opennlp-tools 2.5.9, opentelemetry 1.62.0, lettuce 7.5.2 via pom.xml
 
 ## [6.8-2] - 2026-05-16
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -112,8 +112,13 @@ RUN set -eux; \
       local _value=${2}; \
       xml edit --inplace --update "${_xpath}" --value "${_value}" /tmp/languagetool/pom.xml; \
     }; \
-    patch_property "//*[name()='ch.qos.logback.version']" "1.5.25"; \
-    patch_property "//*[name()='jackson.version']" "2.18.6"; \
+    if [ "${LT_VERSION}" == "6.8" ]; then \
+        patch_property "//*[name()='ch.qos.logback.version']" "1.5.25"; \
+        patch_property "//*[name()='jackson.version']" "2.18.6"; \
+        patch_property "//*[name()='org.apache.opennlp.opennlp-tools.version']" "2.5.9"; \
+        patch_property "//*[name()='io.opentelemetry.version']" "1.62.0"; \
+        patch_property "//*[name()='io.lettuce.version']" "7.5.2.RELEASE"; \
+    fi ; \
     /opt/maven/bin/mvn  \
       --file /tmp/languagetool/pom.xml \
       --projects languagetool-standalone \
@@ -132,16 +137,15 @@ RUN set -eux; \
       local _FILENAME=${_FILENAME%\-*}.jar; \
       wget "${_URL}" -O /languagetool/libs/${_FILENAME}; \
     }; \
-    update_maven_dependency https://repo1.maven.org/maven2/io/netty/netty-buffer/4.2.13.Final/netty-buffer-4.2.13.Final.jar; \
-    update_maven_dependency https://repo1.maven.org/maven2/io/netty/netty-codec-dns/4.2.13.Final/netty-codec-dns-4.2.13.Final.jar; \
-    update_maven_dependency https://repo1.maven.org/maven2/io/netty/netty-codec/4.2.13.Final/netty-codec-4.2.13.Final.jar; \
-    update_maven_dependency https://repo1.maven.org/maven2/io/netty/netty-common/4.2.13.Final/netty-common-4.2.13.Final.jar; \
-    update_maven_dependency https://repo1.maven.org/maven2/io/netty/netty-handler/4.2.13.Final/netty-handler-4.2.13.Final.jar; \
-    update_maven_dependency https://repo1.maven.org/maven2/io/netty/netty-resolver-dns/4.2.13.Final/netty-resolver-dns-4.2.13.Final.jar; \
-    update_maven_dependency https://repo1.maven.org/maven2/io/netty/netty-resolver/4.2.13.Final/netty-resolver-4.2.13.Final.jar; \
-    update_maven_dependency https://repo1.maven.org/maven2/io/netty/netty-transport-native-unix-common/4.2.13.Final/netty-transport-native-unix-common-4.2.13.Final.jar; \
-    update_maven_dependency https://repo1.maven.org/maven2/io/netty/netty-transport/4.2.13.Final/netty-transport-4.2.13.Final.jar; \
-    update_maven_dependency https://repo1.maven.org/maven2/org/apache/opennlp/opennlp-tools/2.5.9/opennlp-tools-2.5.9.jar; \
+    #update_maven_dependency https://repo1.maven.org/maven2/io/netty/netty-buffer/4.2.13.Final/netty-buffer-4.2.13.Final.jar; \
+    #update_maven_dependency https://repo1.maven.org/maven2/io/netty/netty-codec-dns/4.2.13.Final/netty-codec-dns-4.2.13.Final.jar; \
+    #update_maven_dependency https://repo1.maven.org/maven2/io/netty/netty-codec/4.2.13.Final/netty-codec-4.2.13.Final.jar; \
+    #update_maven_dependency https://repo1.maven.org/maven2/io/netty/netty-common/4.2.13.Final/netty-common-4.2.13.Final.jar; \
+    #update_maven_dependency https://repo1.maven.org/maven2/io/netty/netty-handler/4.2.13.Final/netty-handler-4.2.13.Final.jar; \
+    #update_maven_dependency https://repo1.maven.org/maven2/io/netty/netty-resolver-dns/4.2.13.Final/netty-resolver-dns-4.2.13.Final.jar; \
+    #update_maven_dependency https://repo1.maven.org/maven2/io/netty/netty-resolver/4.2.13.Final/netty-resolver-4.2.13.Final.jar; \
+    #update_maven_dependency https://repo1.maven.org/maven2/io/netty/netty-transport-native-unix-common/4.2.13.Final/netty-transport-native-unix-common-4.2.13.Final.jar; \
+    #update_maven_dependency https://repo1.maven.org/maven2/io/netty/netty-transport/4.2.13.Final/netty-transport-4.2.13.Final.jar; \
     echo "patches applied"
 
 RUN set -eux; \


### PR DESCRIPTION
## Summary

- Gates `pom.xml` CVE patches (logback, Jackson, opennlp, opentelemetry, lettuce) behind an `LT_VERSION == 6.8` check so they apply only to the relevant release
- Removes the post-build direct JAR replacement approach for netty and opennlp in favour of patching `pom.xml` at build time

## Test plan

- [ ] CI build-test-image passes for amd64 and arm64
- [ ] Integration tests pass for all 6 scenarios (privileged/unprivileged × rw/ro/no-volumes)
- [ ] Grype CVE scan shows no new critical findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)