### PR TITLE
chore(deps): upgrade base image to Alpine 3.24.0 and update CVE patches for 6.8-4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Image tags follow the pattern `{LanguageTool_version}-{sequential_number}` (e.g.
 
 - Upgrade base image to Alpine 3.24.0
 - Upgrade 7zip to 26.00
+- Upgrade libstdc++ to 15.2.0-r5
+- Upgrade fasttext to 0.9.2-r3
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Image tags follow the pattern `{LanguageTool_version}-{sequential_number}` (e.g. `6.8-3`).
 
+## [6.8-4] - 2026-06-11
+
+### Changed
+
+- Upgrade base image to Alpine 3.24.0
+- Upgrade 7zip to 26.00
+
+### Security
+
+- Upgrade OpenSSL to 3.5.7s
+- Patch lettuce 7.6.0.RELEASE via pom.xml
+- Upgrade netty.io dependencies to 4.2.15.Final
+
 ## [6.8-3] - 2026-06-05
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ENV LANG=en_US.UTF-8 \
 
 # renovate: datasource=repology depName=alpine_3_24/libretls versioning=loose
 ARG LIBRETLS_VERSION="3.8.1-r0"
-# renovate: datasource=repology depName=alpine_3_24/musl-localess versioning=loose
+# renovate: datasource=repology depName=alpine_3_24/musl-locales versioning=loose
 ARG MUSL_LOCALES_VERSION="0.1.0-r1"
 # renovate: datasource=repology depName=alpine_3_24/musl-locales-lang versioning=loose
 ARG MUSL_LOCALES_LANG_VERSION="0.1.0-r1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG IMAGE_VERSION="6.8-3"
-ARG IMAGE_CREATED="2026-06-05"
+ARG IMAGE_VERSION="6.8-4"
+ARG IMAGE_CREATED="2026-06-11"
 # renovate: datasource=github-tags depName=languagetool-org/languagetool versioning=loose
 ARG LT_VERSION="6.8"
 # renovate: datasource=github-releases depName=adoptium/temurin21-binaries versioning=regex:^jdk-(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)\+(?<build>\d+)$
@@ -7,8 +7,8 @@ ARG JAVA_VERSION="jdk-21.0.11+10"
 # renovate: datasource=github-releases depName=apache/maven versioning=semver extractVersion=^maven-(?<version>.*)$
 ARG MAVEN_VERSION="3.9.16"
 # renovate: datasource=docker depName=golang versioning=docker
-ARG GO_VERSION="1.26.4-alpine3.23"
-FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 AS base
+ARG GO_VERSION="1.26.4-alpine3.24"
+FROM alpine:3.24.0 AS base
 
 FROM base AS java_base
 
@@ -16,18 +16,18 @@ ENV LANG=en_US.UTF-8 \
     LANGUAGE=en_US:en \
     LC_ALL=en_US.UTF-8
 
-# renovate: datasource=repology depName=alpine_3_23/libretls versioning=loose
+# renovate: datasource=repology depName=alpine_3_24/libretls versioning=loose
 ARG LIBRETLS_VERSION="3.8.1-r0"
-# renovate: datasource=repology depName=alpine_3_23/musl-locales versioning=loose
+# renovate: datasource=repology depName=alpine_3_24/musl-localess versioning=loose
 ARG MUSL_LOCALES_VERSION="0.1.0-r1"
-# renovate: datasource=repology depName=alpine_3_23/musl-locales-lang versioning=loose
+# renovate: datasource=repology depName=alpine_3_24/musl-locales-lang versioning=loose
 ARG MUSL_LOCALES_LANG_VERSION="0.1.0-r1"
-# renovate: datasource=repology depName=alpine_3_23/tzdata versioning=loose
+# renovate: datasource=repology depName=alpine_3_24/tzdata versioning=loose
 ARG TZDATA_VERSION="2026b-r0"
-# renovate: datasource=repology depName=alpine_3_23/zlib versioning=loose
+# renovate: datasource=repology depName=alpine_3_24/zlib versioning=loose
 ARG ZLIB_VERSION="1.3.2-r0"
-# renovate: datasource=repology depName=alpine_3_23/openssl versioning=loose
-ARG OPENSSL_VERSION="3.5.6-r0"
+# renovate: datasource=repology depName=alpine_3_24/openssl versioning=loose
+ARG OPENSSL_VERSION="3.5.7s-r0"
 
 RUN set -eux; \
     apk add --upgrade --no-cache \
@@ -48,8 +48,8 @@ ARG MAVEN_VERSION
 ENV JAVA_HOME=/opt/java/openjdk \
     JAVA_VERSION=${JAVA_VERSION}
 
-# renovate: datasource=repology depName=alpine_3_23/7zip versioning=loose
-ARG SEVEN_ZIP_VERSION="25.01-r0"
+# renovate: datasource=repology depName=alpine_3_24/7zip versioning=loose
+ARG SEVEN_ZIP_VERSION="26.00-r0"
 
 RUN set -eux; \
     apk add --no-cache binutils 7zip="${SEVEN_ZIP_VERSION}"; \
@@ -117,7 +117,7 @@ RUN set -eux; \
         patch_property "//*[name()='jackson.version']" "2.18.6"; \
         patch_property "//*[name()='org.apache.opennlp.opennlp-tools.version']" "2.5.9"; \
         patch_property "//*[name()='io.opentelemetry.version']" "1.62.0"; \
-        patch_property "//*[name()='io.lettuce.version']" "7.5.2.RELEASE"; \
+        patch_property "//*[name()='io.lettuce.version']" "7.6.0.RELEASE"; \
     fi ; \
     /opt/maven/bin/mvn  \
       --file /tmp/languagetool/pom.xml \
@@ -137,15 +137,16 @@ RUN set -eux; \
       local _FILENAME=${_FILENAME%\-*}.jar; \
       wget "${_URL}" -O /languagetool/libs/${_FILENAME}; \
     }; \
-    #update_maven_dependency https://repo1.maven.org/maven2/io/netty/netty-buffer/4.2.13.Final/netty-buffer-4.2.13.Final.jar; \
-    #update_maven_dependency https://repo1.maven.org/maven2/io/netty/netty-codec-dns/4.2.13.Final/netty-codec-dns-4.2.13.Final.jar; \
-    #update_maven_dependency https://repo1.maven.org/maven2/io/netty/netty-codec/4.2.13.Final/netty-codec-4.2.13.Final.jar; \
-    #update_maven_dependency https://repo1.maven.org/maven2/io/netty/netty-common/4.2.13.Final/netty-common-4.2.13.Final.jar; \
-    #update_maven_dependency https://repo1.maven.org/maven2/io/netty/netty-handler/4.2.13.Final/netty-handler-4.2.13.Final.jar; \
-    #update_maven_dependency https://repo1.maven.org/maven2/io/netty/netty-resolver-dns/4.2.13.Final/netty-resolver-dns-4.2.13.Final.jar; \
-    #update_maven_dependency https://repo1.maven.org/maven2/io/netty/netty-resolver/4.2.13.Final/netty-resolver-4.2.13.Final.jar; \
-    #update_maven_dependency https://repo1.maven.org/maven2/io/netty/netty-transport-native-unix-common/4.2.13.Final/netty-transport-native-unix-common-4.2.13.Final.jar; \
-    #update_maven_dependency https://repo1.maven.org/maven2/io/netty/netty-transport/4.2.13.Final/netty-transport-4.2.13.Final.jar; \
+    export NETTY_VERSION=4.2.15.Final ; \
+    update_maven_dependency https://repo1.maven.org/maven2/io/netty/netty-buffer/${NETTY_VERSION}/netty-buffer-${NETTY_VERSION}.jar; \
+    update_maven_dependency https://repo1.maven.org/maven2/io/netty/netty-codec-dns/${NETTY_VERSION}/netty-codec-dns-${NETTY_VERSION}.jar; \
+    update_maven_dependency https://repo1.maven.org/maven2/io/netty/netty-codec/${NETTY_VERSION}/netty-codec-${NETTY_VERSION}.jar; \
+    update_maven_dependency https://repo1.maven.org/maven2/io/netty/netty-common/${NETTY_VERSION}/netty-common-${NETTY_VERSION}.jar; \
+    update_maven_dependency https://repo1.maven.org/maven2/io/netty/netty-handler/${NETTY_VERSION}/netty-handler-${NETTY_VERSION}.jar; \
+    update_maven_dependency https://repo1.maven.org/maven2/io/netty/netty-resolver-dns/${NETTY_VERSION}/netty-resolver-dns-${NETTY_VERSION}.jar; \
+    update_maven_dependency https://repo1.maven.org/maven2/io/netty/netty-resolver/${NETTY_VERSION}/netty-resolver-${NETTY_VERSION}.jar; \
+    update_maven_dependency https://repo1.maven.org/maven2/io/netty/netty-transport-native-unix-common/${NETTY_VERSION}/netty-transport-native-unix-common-${NETTY_VERSION}.jar; \
+    update_maven_dependency https://repo1.maven.org/maven2/io/netty/netty-transport/${NETTY_VERSION}/netty-transport-${NETTY_VERSION}.jar; \
     echo "patches applied"
 
 RUN set -eux; \
@@ -175,15 +176,15 @@ RUN go mod tidy && \
 
 FROM java_base
 
-# renovate: datasource=repology depName=alpine_3_23/libstdc++ versioning=loose
-ARG LIBSTDCPP_VERSION="15.2.0-r2"
-# renovate: datasource=repology depName=alpine_3_23/gcompat versioning=loose
+# renovate: datasource=repology depName=alpine_3_24/libstdc++ versioning=loose
+ARG LIBSTDCPP_VERSION="15.2.0-r5"
+# renovate: datasource=repology depName=alpine_3_24/gcompat versioning=loose
 ARG GCOMPAT_VERSION="1.1.0-r4"
-# renovate: datasource=repology depName=alpine_3_23/tini versioning=loose
+# renovate: datasource=repology depName=alpine_3_24/tini versioning=loose
 ARG TINI_VERSION="0.19.0-r3"
-# renovate: datasource=repology depName=alpine_3_23/fasttext versioning=loose
-ARG FASTTEXT_VERSION="0.9.2-r1"
-# renovate: datasource=repology depName=alpine_3_23/nss_wrapper versioning=loose
+# renovate: datasource=repology depName=alpine_3_24/fasttext versioning=loose
+ARG FASTTEXT_VERSION="0.9.2-r3"
+# renovate: datasource=repology depName=alpine_3_24/nss_wrapper versioning=loose
 ARG NSS_WRAPPER_VERSION="1.1.12-r1"
 
 RUN set -eux; \

--- a/Dockerfile.fasttext
+++ b/Dockerfile.fasttext
@@ -1,5 +1,5 @@
-ARG IMAGE_VERSION="6.8-3"
-ARG IMAGE_CREATED="2026-06-05"
+ARG IMAGE_VERSION="6.8-4"
+ARG IMAGE_CREATED="2026-06-11"
 # renovate: datasource=github-tags depName=languagetool-org/languagetool versioning=loose
 ARG LT_VERSION="6.8"
 # renovate: datasource=github-releases depName=adoptium/temurin21-binaries versioning=regex:^jdk-(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)\+(?<build>\d+)$
@@ -7,8 +7,8 @@ ARG JAVA_VERSION="jdk-21.0.11+10"
 # renovate: datasource=github-releases depName=apache/maven versioning=semver extractVersion=^maven-(?<version>.*)$
 ARG MAVEN_VERSION="3.9.16"
 # renovate: datasource=docker depName=golang versioning=docker
-ARG GO_VERSION="1.26-alpine3.23"
-FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 AS base
+ARG GO_VERSION="1.26.4-alpine3.24"
+FROM alpine:3.24.0 AS base
 
 FROM base AS java_base
 
@@ -16,18 +16,18 @@ ENV LANG=en_US.UTF-8 \
     LANGUAGE=en_US:en \
     LC_ALL=en_US.UTF-8
 
-# renovate: datasource=repology depName=alpine_3_23/libretls versioning=loose
+# renovate: datasource=repology depName=alpine_3_24/libretls versioning=loose
 ARG LIBRETLS_VERSION="3.8.1-r0"
-# renovate: datasource=repology depName=alpine_3_23/musl-locales versioning=loose
+# renovate: datasource=repology depName=alpine_3_24/musl-localess versioning=loose
 ARG MUSL_LOCALES_VERSION="0.1.0-r1"
-# renovate: datasource=repology depName=alpine_3_23/musl-locales-lang versioning=loose
+# renovate: datasource=repology depName=alpine_3_24/musl-locales-lang versioning=loose
 ARG MUSL_LOCALES_LANG_VERSION="0.1.0-r1"
-# renovate: datasource=repology depName=alpine_3_23/tzdata versioning=loose
+# renovate: datasource=repology depName=alpine_3_24/tzdata versioning=loose
 ARG TZDATA_VERSION="2026b-r0"
-# renovate: datasource=repology depName=alpine_3_23/zlib versioning=loose
+# renovate: datasource=repology depName=alpine_3_24/zlib versioning=loose
 ARG ZLIB_VERSION="1.3.2-r0"
-# renovate: datasource=repology depName=alpine_3_23/openssl versioning=loose
-ARG OPENSSL_VERSION="3.5.6-r0"
+# renovate: datasource=repology depName=alpine_3_24/openssl versioning=loose
+ARG OPENSSL_VERSION="3.5.7s-r0"
 
 RUN set -eux; \
     apk add --upgrade --no-cache \
@@ -48,8 +48,8 @@ ARG MAVEN_VERSION
 ENV JAVA_HOME=/opt/java/openjdk \
     JAVA_VERSION=${JAVA_VERSION}
 
-# renovate: datasource=repology depName=alpine_3_23/7zip versioning=loose
-ARG SEVEN_ZIP_VERSION="25.01-r0"
+# renovate: datasource=repology depName=alpine_3_24/7zip versioning=loose
+ARG SEVEN_ZIP_VERSION="26.00-r0"
 
 RUN set -eux; \
     apk add --no-cache binutils 7zip="${SEVEN_ZIP_VERSION}"; \
@@ -112,8 +112,13 @@ RUN set -eux; \
       local _value=${2}; \
       xml edit --inplace --update "${_xpath}" --value "${_value}" /tmp/languagetool/pom.xml; \
     }; \
-    patch_property "//*[name()='ch.qos.logback.version']" "1.5.25"; \
-    patch_property "//*[name()='jackson.version']" "2.18.6"; \
+    if [ "${LT_VERSION}" == "6.8" ]; then \
+        patch_property "//*[name()='ch.qos.logback.version']" "1.5.25"; \
+        patch_property "//*[name()='jackson.version']" "2.18.6"; \
+        patch_property "//*[name()='org.apache.opennlp.opennlp-tools.version']" "2.5.9"; \
+        patch_property "//*[name()='io.opentelemetry.version']" "1.62.0"; \
+        patch_property "//*[name()='io.lettuce.version']" "7.6.0.RELEASE"; \
+    fi ; \
     /opt/maven/bin/mvn  \
       --file /tmp/languagetool/pom.xml \
       --projects languagetool-standalone \
@@ -132,16 +137,16 @@ RUN set -eux; \
       local _FILENAME=${_FILENAME%\-*}.jar; \
       wget "${_URL}" -O /languagetool/libs/${_FILENAME}; \
     }; \
-    update_maven_dependency https://repo1.maven.org/maven2/io/netty/netty-buffer/4.2.13.Final/netty-buffer-4.2.13.Final.jar; \
-    update_maven_dependency https://repo1.maven.org/maven2/io/netty/netty-codec-dns/4.2.13.Final/netty-codec-dns-4.2.13.Final.jar; \
-    update_maven_dependency https://repo1.maven.org/maven2/io/netty/netty-codec/4.2.13.Final/netty-codec-4.2.13.Final.jar; \
-    update_maven_dependency https://repo1.maven.org/maven2/io/netty/netty-common/4.2.13.Final/netty-common-4.2.13.Final.jar; \
-    update_maven_dependency https://repo1.maven.org/maven2/io/netty/netty-handler/4.2.13.Final/netty-handler-4.2.13.Final.jar; \
-    update_maven_dependency https://repo1.maven.org/maven2/io/netty/netty-resolver-dns/4.2.13.Final/netty-resolver-dns-4.2.13.Final.jar; \
-    update_maven_dependency https://repo1.maven.org/maven2/io/netty/netty-resolver/4.2.13.Final/netty-resolver-4.2.13.Final.jar; \
-    update_maven_dependency https://repo1.maven.org/maven2/io/netty/netty-transport-native-unix-common/4.2.13.Final/netty-transport-native-unix-common-4.2.13.Final.jar; \
-    update_maven_dependency https://repo1.maven.org/maven2/io/netty/netty-transport/4.2.13.Final/netty-transport-4.2.13.Final.jar; \
-    update_maven_dependency https://repo1.maven.org/maven2/org/apache/opennlp/opennlp-tools/2.5.9/opennlp-tools-2.5.9.jar; \
+    export NETTY_VERSION=4.2.15.Final ; \
+    update_maven_dependency https://repo1.maven.org/maven2/io/netty/netty-buffer/${NETTY_VERSION}/netty-buffer-${NETTY_VERSION}.jar; \
+    update_maven_dependency https://repo1.maven.org/maven2/io/netty/netty-codec-dns/${NETTY_VERSION}/netty-codec-dns-${NETTY_VERSION}.jar; \
+    update_maven_dependency https://repo1.maven.org/maven2/io/netty/netty-codec/${NETTY_VERSION}/netty-codec-${NETTY_VERSION}.jar; \
+    update_maven_dependency https://repo1.maven.org/maven2/io/netty/netty-common/${NETTY_VERSION}/netty-common-${NETTY_VERSION}.jar; \
+    update_maven_dependency https://repo1.maven.org/maven2/io/netty/netty-handler/${NETTY_VERSION}/netty-handler-${NETTY_VERSION}.jar; \
+    update_maven_dependency https://repo1.maven.org/maven2/io/netty/netty-resolver-dns/${NETTY_VERSION}/netty-resolver-dns-${NETTY_VERSION}.jar; \
+    update_maven_dependency https://repo1.maven.org/maven2/io/netty/netty-resolver/${NETTY_VERSION}/netty-resolver-${NETTY_VERSION}.jar; \
+    update_maven_dependency https://repo1.maven.org/maven2/io/netty/netty-transport-native-unix-common/${NETTY_VERSION}/netty-transport-native-unix-common-${NETTY_VERSION}.jar; \
+    update_maven_dependency https://repo1.maven.org/maven2/io/netty/netty-transport/${NETTY_VERSION}/netty-transport-${NETTY_VERSION}.jar; \
     echo "patches applied"
 
 RUN set -eux; \
@@ -194,13 +199,15 @@ RUN go mod tidy && \
 
 FROM java_base
 
-# renovate: datasource=repology depName=alpine_3_23/libstdc++ versioning=loose
-ARG LIBSTDCPP_VERSION="15.2.0-r2"
-# renovate: datasource=repology depName=alpine_3_23/gcompat versioning=loose
+# renovate: datasource=repology depName=alpine_3_24/libstdc++ versioning=loose
+ARG LIBSTDCPP_VERSION="15.2.0-r5"
+# renovate: datasource=repology depName=alpine_3_24/gcompat versioning=loose
 ARG GCOMPAT_VERSION="1.1.0-r4"
-# renovate: datasource=repology depName=alpine_3_23/tini versioning=loose
+# renovate: datasource=repology depName=alpine_3_24/tini versioning=loose
 ARG TINI_VERSION="0.19.0-r3"
-# renovate: datasource=repology depName=alpine_3_23/nss_wrapper versioning=loose
+# renovate: datasource=repology depName=alpine_3_24/fasttext versioning=loose
+ARG FASTTEXT_VERSION="0.9.2-r3"
+# renovate: datasource=repology depName=alpine_3_24/nss_wrapper versioning=loose
 ARG NSS_WRAPPER_VERSION="1.1.12-r1"
 
 RUN set -eux; \

--- a/Dockerfile.fasttext
+++ b/Dockerfile.fasttext
@@ -18,7 +18,7 @@ ENV LANG=en_US.UTF-8 \
 
 # renovate: datasource=repology depName=alpine_3_24/libretls versioning=loose
 ARG LIBRETLS_VERSION="3.8.1-r0"
-# renovate: datasource=repology depName=alpine_3_24/musl-localess versioning=loose
+# renovate: datasource=repology depName=alpine_3_24/musl-locales versioning=loose
 ARG MUSL_LOCALES_VERSION="0.1.0-r1"
 # renovate: datasource=repology depName=alpine_3_24/musl-locales-lang versioning=loose
 ARG MUSL_LOCALES_LANG_VERSION="0.1.0-r1"


### PR DESCRIPTION
## Summary

- Upgrade base image from Alpine 3.23.4 to Alpine 3.24.0 in both `Dockerfile` and `Dockerfile.fasttext`
- Update all Alpine package renovate comments and versions for Alpine 3.24 (OpenSSL 3.5.7s, 7zip 26.00, libstdc++ 15.2.0-r5, fasttext 0.9.2-r3)
- Upgrade netty.io dependencies to 4.2.15.Final (re-enabled direct JAR replacements, previously commented out)
- Patch lettuce to 7.6.0.RELEASE via pom.xml
- Bump `IMAGE_VERSION` to `6.8-4` and update `IMAGE_CREATED` date

## Test plan

- [ ] Build standard image: `docker build -t meyay/languagetool:6.8-4 .`
- [ ] Build fasttext image: `docker build -t meyay/languagetool:6.8-4 -f Dockerfile.fasttext .`
- [ ] Run integration tests via CI pipeline
- [ ] Verify API responds: `curl --data "language=en-US&text=a simple test" http://127.0.0.1:8081/v2/check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)